### PR TITLE
UI: Improve error messages on login screen

### DIFF
--- a/observability_ui/apps/basic-auth/src/app/login/login.component.ts
+++ b/observability_ui/apps/basic-auth/src/app/login/login.component.ts
@@ -45,7 +45,7 @@ export class LoginComponent {
     ).subscribe({
       next: (url) => this.router.navigateByUrl(url),
       error: (error) => {
-        this.loginError = 'Invalid credentials: Wrong email or password.';
+        this.loginError = error.error?.error || (error.status === 0 ? 'Unable to reach Observability API.' : error.message);
         console.error(error);
       },
     });


### PR DESCRIPTION
With this change, we default to the error message from the API if present. Example, on 401:
<img width="784" alt="Screenshot 2024-05-09 at 3 09 10 PM" src="https://github.com/DataKitchen/dataops-observability/assets/110687694/31c34656-f976-4349-9d97-f2eab08a061f">


When the status code is 0:
<img width="781" alt="Screenshot 2024-05-09 at 3 10 29 PM" src="https://github.com/DataKitchen/dataops-observability/assets/110687694/39736409-81e9-4979-af72-78de2ffcf9c1">

In other cases, we default to the "message" field on the response.