### PR TITLE
UI: Fix time display issue on runs table

### DIFF
--- a/observability_ui/apps/shell/src/app/projects/runs/runs-table/run-time/run-time.component.html
+++ b/observability_ui/apps/shell/src/app/projects/runs/runs-table/run-time/run-time.component.html
@@ -23,6 +23,6 @@
 </small>
 
 <ng-template #tooltipTpl>
-  <div>Late by: {{actual | duration:expected}}</div>
+  <div>Late by: {{(actual || currentTime) | duration:expected}}</div>
   <div>Expected: {{expected | parseDate | date:"MMM d, h:mm:ss a"}}</div>
 </ng-template>

--- a/observability_ui/apps/shell/src/app/projects/runs/runs-table/run-time/run-time.component.ts
+++ b/observability_ui/apps/shell/src/app/projects/runs/runs-table/run-time/run-time.component.ts
@@ -19,6 +19,11 @@ export class RunTimeComponent {
   @Input() iconLabel: string;
 
   private _actual = signal<string | null>(null);
+  get actual() {
+    return this._actual();
+  }
+
+  currentTime = new Date()
 
   time = computed(() => {
     return this._actual() || this.expected;


### PR DESCRIPTION
Before: Start times were displayed as "scheduled" even after the run started.
<img width="606" alt="Screenshot 2024-05-21 at 3 03 05 PM" src="https://github.com/DataKitchen/dataops-observability/assets/110687694/a2ec03ba-1aac-4727-af5c-474a29cabb1a">

After:
<img width="583" alt="Screenshot 2024-05-21 at 3 02 59 PM" src="https://github.com/DataKitchen/dataops-observability/assets/110687694/51911c29-a0b2-423e-82d6-39096ec552c6">
