### PR TITLE
Package updates & linter/typing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 *<p style="text-align: center;">DataOps Observability is part of DataKitchen's Open Source Data Observability. DataOps Observability monitors every data journey from data source to customer value, from any team development environment into production, across every tool, team, environment, and customer so that problems are detected, localized, and understood immediately.</p>*
 
-[![DatKitchen Open Source Data Observability](https://datakitchen.io/wp-content/uploads/2024/04/both-products.png)](https://datakitchen.storylane.io/share/g01ss0plyamz)
+[![DataKitchen Open Source Data Observability](https://datakitchen.io/wp-content/uploads/2024/04/both-products.png)](https://datakitchen.storylane.io/share/g01ss0plyamz)
 [Interactive Product Tour](https://datakitchen.storylane.io/share/g01ss0plyamz)
 
 ## Developer Setup
@@ -100,9 +100,7 @@ We enforce the use of certain linting tools. To not get caught by the build-syst
 
 The following hooks are enabled in pre-commit:
 
-- `black`: The black formatter is enforced on the project. We use a basic configuration. Ideally this should solve any and all
-formatting questions we might encounter.
-- `isort`: the isort import-sorter is enforced on the project. We use it with the `black` profile.
+- `ruff`: Handles code formatting, import sorting, and linting
 
 To enable pre-commit from within your virtual environment, simply run:
 

--- a/agent_api/config/defaults.py
+++ b/agent_api/config/defaults.py
@@ -5,13 +5,12 @@ Settings here may be overridden by settings in development, test, production, et
 """
 
 import os
-from typing import Optional
 
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
 from common.entities import Service
 
-PROPAGATE_EXCEPTIONS: Optional[bool] = None
-SERVER_NAME: Optional[str] = os.environ.get("AGENT_API_HOSTNAME")  # Use flask defaults if none set
+PROPAGATE_EXCEPTIONS: bool | None = None
+SERVER_NAME: str | None = os.environ.get("AGENT_API_HOSTNAME")  # Use flask defaults if none set
 USE_X_SENDFILE: bool = False  # If we serve files enable this in production settings when webserver support configured
 
 # Application settings

--- a/agent_api/config/local.py
+++ b/agent_api/config/local.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-PROPAGATE_EXCEPTIONS: Optional[bool] = True
+PROPAGATE_EXCEPTIONS: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"

--- a/agent_api/config/minikube.py
+++ b/agent_api/config/minikube.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-TESTING: Optional[bool] = True
+TESTING: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"

--- a/agent_api/endpoints/v1/heartbeat.py
+++ b/agent_api/endpoints/v1/heartbeat.py
@@ -1,7 +1,7 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from http import HTTPStatus
-from typing import Optional, Union, cast
+from typing import Union, cast
 from uuid import UUID
 
 from flask import Response, g, make_response
@@ -23,7 +23,7 @@ def _update_or_create(
     version: str,
     project_id: Union[str, UUID],
     latest_heartbeat: datetime,
-    latest_event_timestamp: Optional[datetime],
+    latest_event_timestamp: datetime | None,
 ) -> None:
     try:
         agent = Agent.select().where(Agent.key == key, Agent.tool == tool, Agent.project_id == project_id).get()
@@ -57,7 +57,7 @@ class Heartbeat(BaseView):
 
     def post(self) -> Response:
         data = self.parse_body(schema=HeartbeatSchema())
-        data["latest_heartbeat"] = datetime.now(tz=timezone.utc)
+        data["latest_heartbeat"] = datetime.now(tz=UTC)
         data["project_id"] = g.project.id
         _update_or_create(**data)
         return make_response("", HTTPStatus.NO_CONTENT)

--- a/agent_api/tests/integration/v1_endpoints/test_heartbeat.py
+++ b/agent_api/tests/integration/v1_endpoints/test_heartbeat.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from http import HTTPStatus
 
 import pytest
@@ -9,7 +9,7 @@ from common.entities.agent import AgentStatus
 
 @pytest.mark.integration
 def test_agent_heartbeat(client, database_ctx, headers):
-    last_event_timestamp = datetime(2023, 10, 20, 4, 42, 42, tzinfo=timezone.utc)
+    last_event_timestamp = datetime(2023, 10, 20, 4, 42, 42, tzinfo=UTC)
     data = {
         "key": "test-key",
         "tool": "test-tool",
@@ -35,7 +35,7 @@ def test_agent_heartbeat_no_event_timestamp(client, database_ctx, headers):
 
 @pytest.mark.integration
 def test_agent_heartbeat_update(client, database_ctx, headers):
-    last_event_timestamp = datetime(2023, 10, 20, 4, 42, 42, tzinfo=timezone.utc)
+    last_event_timestamp = datetime(2023, 10, 20, 4, 42, 42, tzinfo=UTC)
     data = {
         "key": "test-key",
         "tool": "test-tool",
@@ -47,7 +47,7 @@ def test_agent_heartbeat_update(client, database_ctx, headers):
     assert HTTPStatus.NO_CONTENT == response_1.status_code, response_1.json
 
     # The latest_event_timestamp should be older than "now"
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     agent_1 = Agent.select().get()
     assert agent_1.latest_heartbeat < now
     assert agent_1.status == AgentStatus.ONLINE
@@ -62,7 +62,7 @@ def test_agent_heartbeat_update(client, database_ctx, headers):
 
 @pytest.mark.integration
 def test_agent_heartbeat_existing_update(client, database_ctx, headers):
-    last_event_timestamp = datetime(2023, 10, 20, 4, 42, 42, tzinfo=timezone.utc)
+    last_event_timestamp = datetime(2023, 10, 20, 4, 42, 42, tzinfo=UTC)
     data_1 = {
         "key": "test-key",
         "tool": "test-tool",
@@ -79,7 +79,7 @@ def test_agent_heartbeat_existing_update(client, database_ctx, headers):
 
     data_2 = data_1.copy()
     data_2["version"] = "12.0.3"
-    data_2["latest_event_timestamp"] = datetime(2023, 10, 20, 4, 44, 44, tzinfo=timezone.utc).isoformat()
+    data_2["latest_event_timestamp"] = datetime(2023, 10, 20, 4, 44, 44, tzinfo=UTC).isoformat()
 
     response_2 = client.post("/agent/v1/heartbeat", json=data_2, headers=headers)
     assert HTTPStatus.NO_CONTENT == response_2.status_code, response_2.json

--- a/cli/base.py
+++ b/cli/base.py
@@ -4,7 +4,7 @@ import sys
 from argparse import ArgumentParser
 from logging.config import dictConfig
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable
 
 from log_color import ColorFormatter, ColorStripper
@@ -80,7 +80,7 @@ class DatabaseScriptBase(ScriptBase):
         LOG.info("#g<\u2714> Established #c<%s> connection to #c<%s>", DB.obj.__class__.__name__, DB.obj.database)
 
 
-def logging_init(*, level: str, logfile: Optional[str] = None) -> None:
+def logging_init(*, level: str, logfile: str | None = None) -> None:
     """Given the log level and an optional logging file location, configure all logging."""
     # Don't bother with a file handler if we're not logging to a file
     handlers = ["console", "filehandler"] if logfile else ["console"]

--- a/cli/entry_points/database_schema.py
+++ b/cli/entry_points/database_schema.py
@@ -1,6 +1,6 @@
 import re
 from argparse import ArgumentParser
-from typing import Any, Optional
+from typing import Any
 from re import Pattern
 from collections.abc import Iterable
 
@@ -19,7 +19,7 @@ class MysqlPrintDatabase(MySQLDatabase):
     def __init__(self) -> None:
         super().__init__("")
 
-    def execute_sql(self, sql: str, params: Optional[Iterable[Any]] = None, commit: Optional[bool] = None) -> None:
+    def execute_sql(self, sql: str, params: Iterable[Any] | None = None, commit: bool | None = None) -> None:
         if params:
             raise Exception(f"Params are not expected to be needed to run DDL SQL, but found {params}")
         if match := self._create_table_re.match(sql):

--- a/cli/entry_points/gen_events.py
+++ b/cli/entry_points/gen_events.py
@@ -7,7 +7,7 @@ import re
 import time
 from argparse import Action, ArgumentParser, Namespace
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Union
 from collections.abc import Sequence
 
 from requests_extensions import get_session
@@ -90,7 +90,7 @@ def make_events_action(event_id: str) -> type[Action]:
             parser: ArgumentParser,
             namespace: Namespace,
             values: Union[str, Sequence[Any], None],
-            option_string: Optional[str] = None,
+            option_string: str | None = None,
         ) -> None:
             event_data = {}
             remove_fields = []

--- a/cli/entry_points/graph_schema.py
+++ b/cli/entry_points/graph_schema.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Any
 
 from jinja2 import Environment, FileSystemLoader
 from peewee import Field, ForeignKeyField, ManyToManyField, Model
@@ -54,7 +55,7 @@ class GraphSchema(ScriptBase):
         dot_parts = [head.render({})]
 
         # Initial context/config
-        model_context = []
+        model_context: list[dict[str, Any]] = []
 
         LOG.info("#m<Graphing models...>")
         for name, model in model_map.items():

--- a/cli/lib.py
+++ b/cli/lib.py
@@ -2,7 +2,6 @@ import os
 import re
 import textwrap
 from argparse import ArgumentParser, ArgumentTypeError
-from typing import Optional
 from uuid import UUID
 
 from log_color.colors import ColorStr
@@ -21,7 +20,7 @@ def uuid_type(arg: str) -> UUID:
 def slice_type(arg: str) -> slice:
     """Convert an argument to a slice; for simplicity, disallow negative slice values and steps."""
 
-    def _int_or_none(val: str) -> Optional[int]:
+    def _int_or_none(val: str) -> int | None:
         if not val:
             return None
         else:

--- a/common/actions/action.py
+++ b/common/actions/action.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 import logging
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from common.entities import Action, Rule
@@ -35,15 +35,15 @@ class InvalidActionTemplate(ActionException):
 
 class ActionResult(NamedTuple):
     result: bool
-    response: Optional[dict]
-    exception: Optional[Exception]
+    response: dict | None
+    exception: Exception | None
 
 
 class BaseAction:
     required_arguments: set = set()
     requires_action_template: bool = False
 
-    def __init__(self, action_template: Optional[Action], override_arguments: dict) -> None:
+    def __init__(self, action_template: Action | None, override_arguments: dict) -> None:
         if self.requires_action_template and not action_template:
             raise ActionTemplateRequired(f"'{self.__class__.__name__}' requires an action template to be set")
 
@@ -70,7 +70,7 @@ class BaseAction:
         if missing_args:
             raise ValueError(f"Required arguments {missing_args} missing for {self.__class__.__name__}")
 
-    def _run(self, event: EVENT_TYPE, rule: Rule, journey_id: Optional[UUID]) -> ActionResult:
+    def _run(self, event: EVENT_TYPE, rule: Rule, journey_id: UUID | None) -> ActionResult:
         raise NotImplementedError("Base Action cannot be executed")
 
     def _store_action_result(self, action_result: ActionResult) -> None:
@@ -88,7 +88,7 @@ class BaseAction:
                 exc_info=action_result.exception,
             )
 
-    def execute(self, event: EVENT_TYPE, rule: Rule, journey_id: Optional[UUID]) -> bool:
+    def execute(self, event: EVENT_TYPE, rule: Rule, journey_id: UUID | None) -> bool:
         action_result = self._run(event, rule, journey_id)
         self._store_action_result(action_result)
         return action_result.result

--- a/common/actions/action_factory.py
+++ b/common/actions/action_factory.py
@@ -1,6 +1,5 @@
 __all__ = ["ACTION_CLASS_MAP", "action_factory"]
 
-from typing import Optional
 
 from common.entities import Action
 
@@ -11,7 +10,7 @@ from common.actions.webhook_action import WebhookAction
 ACTION_CLASS_MAP: dict[str, type[BaseAction]] = {"CALL_WEBHOOK": WebhookAction, "SEND_EMAIL": SendEmailAction}
 
 
-def action_factory(implementation: str, action_args: dict, template: Optional[Action]) -> BaseAction:
+def action_factory(implementation: str, action_args: dict, template: Action | None) -> BaseAction:
     try:
         action_class = ACTION_CLASS_MAP[implementation]
     except KeyError as ke:

--- a/common/actions/data_points.py
+++ b/common/actions/data_points.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, Optional, cast
+from typing import Any, cast
 from collections.abc import Callable, Iterator
 from uuid import UUID
 
@@ -102,7 +102,7 @@ class ProjectDataPoints(NamespacedDataPointsBase):
             "name": self._name,
         }
 
-    def _id(self) -> Optional[UUID]:
+    def _id(self) -> UUID | None:
         return self.event.project_id
 
     def _name(self) -> str:
@@ -120,16 +120,16 @@ class ComponentDataPoints(NamespacedDataPointsBase):
             "type": self._type,
         }
 
-    def _id(self) -> Optional[UUID]:
+    def _id(self) -> UUID | None:
         return self.event.component_id
 
-    def _key(self) -> Optional[str]:
+    def _key(self) -> str | None:
         return self.event.component_key
 
-    def _name(self) -> Optional[str]:
+    def _name(self) -> str | None:
         return self.event.component.display_name
 
-    def _type(self) -> Optional[str]:
+    def _type(self) -> str | None:
         return self.event.component_type.name
 
 
@@ -142,13 +142,13 @@ class PipelineDataPoints(NamespacedDataPointsBase):
             "name": self._name,
         }
 
-    def _id(self) -> Optional[UUID]:
+    def _id(self) -> UUID | None:
         return self.event.pipeline_id
 
-    def _key(self) -> Optional[str]:
+    def _key(self) -> str | None:
         return self.event.pipeline_key
 
-    def _name(self) -> Optional[str]:
+    def _name(self) -> str | None:
         return cast(str, self.event.pipeline.display_name)
 
 
@@ -170,13 +170,13 @@ class RunDataPoints(NamespacedDataPointsBase):
             "expected_end_time_formatted": self._expected_end_time_formatted,
         }
 
-    def _id(self) -> Optional[UUID]:
+    def _id(self) -> UUID | None:
         return self.event.run_id
 
-    def _key(self) -> Optional[str]:
+    def _key(self) -> str | None:
         return self.event.run_key
 
-    def _name(self) -> Optional[str]:
+    def _name(self) -> str | None:
         return self.event.run_name
 
     def _status(self) -> str:
@@ -195,7 +195,7 @@ class RunDataPoints(NamespacedDataPointsBase):
                 return datetime_formatted(start_time)
         return "N/A"
 
-    def _expected_start_dt(self) -> Optional[datetime]:
+    def _expected_start_dt(self) -> datetime | None:
         try:
             run = getattr(self.event, "run", None)
         except DoesNotExist:
@@ -206,11 +206,11 @@ class RunDataPoints(NamespacedDataPointsBase):
                     return cast(datetime, expected_start_time)
         return None
 
-    def _expected_start_time(self) -> Optional[str]:
+    def _expected_start_time(self) -> str | None:
         val = self._expected_start_dt()
         return datetime_iso8601(val) if val else None
 
-    def _expected_start_time_formatted(self) -> Optional[str]:
+    def _expected_start_time_formatted(self) -> str | None:
         val = self._expected_start_dt()
         return datetime_formatted(val) if val else None
 
@@ -226,7 +226,7 @@ class RunDataPoints(NamespacedDataPointsBase):
                 return datetime_formatted(end_time)
         return "N/A"
 
-    def _expected_end_dt(self) -> Optional[datetime]:
+    def _expected_end_dt(self) -> datetime | None:
         try:
             run = getattr(self.event, "run", None)
         except DoesNotExist:
@@ -237,11 +237,11 @@ class RunDataPoints(NamespacedDataPointsBase):
                     return cast(datetime, expected_end_time)
         return None
 
-    def _expected_end_time(self) -> Optional[str]:
+    def _expected_end_time(self) -> str | None:
         val = self._expected_end_dt()
         return datetime_iso8601(val) if val else None
 
-    def _expected_end_time_formatted(self) -> Optional[str]:
+    def _expected_end_time_formatted(self) -> str | None:
         val = self._expected_end_dt()
         return datetime_formatted(val) if val else None
 
@@ -255,10 +255,10 @@ class TaskDataPoints(NamespacedDataPointsBase):
             "name": self._name,
         }
 
-    def _id(self) -> Optional[UUID]:
+    def _id(self) -> UUID | None:
         return self.event.task_id
 
-    def _key(self) -> Optional[str]:
+    def _key(self) -> str | None:
         ret: str = getattr(self.event, "task_key")
         return ret
 
@@ -278,7 +278,7 @@ class RunTaskDataPoints(NamespacedDataPointsBase):
             "end_time_formatted": self._end_time_formatted,
         }
 
-    def _id(self) -> Optional[UUID]:
+    def _id(self) -> UUID | None:
         return self.event.run_task_id
 
     def _status(self) -> str:
@@ -408,7 +408,7 @@ class AlertEventDataPoints(NamespacedDataPointsBase):
         _type: str = self.event.type.value
         return _type
 
-    def _expected_start_dt(self) -> Optional[datetime]:
+    def _expected_start_dt(self) -> datetime | None:
         try:
             alert = getattr(self.event, "alert", None)
         except DoesNotExist:
@@ -419,7 +419,7 @@ class AlertEventDataPoints(NamespacedDataPointsBase):
                     return cast(datetime, expected_start_time)
         return None
 
-    def _expected_end_dt(self) -> Optional[datetime]:
+    def _expected_end_dt(self) -> datetime | None:
         try:
             alert = getattr(self.event, "alert", None)
         except DoesNotExist:
@@ -430,11 +430,11 @@ class AlertEventDataPoints(NamespacedDataPointsBase):
                     return cast(datetime, expected_end_time)
         return None
 
-    def _expected_start_time_formatted(self) -> Optional[str]:
+    def _expected_start_time_formatted(self) -> str | None:
         val = self._expected_start_dt()
         return datetime_formatted(val) if val else None
 
-    def _expected_end_time_formatted(self) -> Optional[str]:
+    def _expected_end_time_formatted(self) -> str | None:
         val = self._expected_end_dt()
         return datetime_formatted(val) if val else None
 
@@ -448,16 +448,16 @@ class InternalComponentDataPoints(NamespacedDataPointsBase):
             "name": self._name,
         }
 
-    def _id(self) -> Optional[UUID]:
-        id: Optional[UUID] = self.event.batch_pipeline_id
+    def _id(self) -> UUID | None:
+        id: UUID | None = self.event.batch_pipeline_id
         return id
 
-    def _key(self) -> Optional[str]:
-        key: Optional[str] = self.event.batch_pipeline.key
+    def _key(self) -> str | None:
+        key: str | None = self.event.batch_pipeline.key
         return key
 
-    def _name(self) -> Optional[str]:
-        name: Optional[str] = self.event.batch_pipeline.display_name
+    def _name(self) -> str | None:
+        name: str | None = self.event.batch_pipeline.display_name
         return name
 
 
@@ -470,16 +470,16 @@ class RunAlertDatapoints(NamespacedDataPointsBase):
             "name": self._name,
         }
 
-    def _id(self) -> Optional[UUID]:
-        id: Optional[UUID] = self.event.run.id
+    def _id(self) -> UUID | None:
+        id: UUID | None = self.event.run.id
         return id
 
-    def _key(self) -> Optional[str]:
-        key: Optional[str] = self.event.run.key
+    def _key(self) -> str | None:
+        key: str | None = self.event.run.key
         return key
 
-    def _name(self) -> Optional[str]:
-        name: Optional[str] = self.event.run.name
+    def _name(self) -> str | None:
+        name: str | None = self.event.run.name
         return name
 
 
@@ -493,26 +493,26 @@ class RuleDataPoints(NamespacedDataPointsBase):
             "run_state_trigger_successive": self._run_state_trigger_successive,
         }
 
-    def _run_state_matches(self) -> Optional[str]:
+    def _run_state_matches(self) -> str | None:
         try:
-            matches: Optional[str] = self.rule.rule_data["conditions"][0]["run_state"]["matches"]
+            matches: str | None = self.rule.rule_data["conditions"][0]["run_state"]["matches"]
             return matches
         except Exception:
             return None
 
-    def _run_state_count(self) -> Optional[str]:
+    def _run_state_count(self) -> str | None:
         try:
             return str(self.rule.rule_data["conditions"][0]["run_state"]["count"])
         except Exception:
             return None
 
-    def _run_state_group_run_name(self) -> Optional[str]:
+    def _run_state_group_run_name(self) -> str | None:
         try:
             return str(self.rule.rule_data["conditions"][0]["run_state"]["group_run_name"])
         except Exception:
             return None
 
-    def _run_state_trigger_successive(self) -> Optional[str]:
+    def _run_state_trigger_successive(self) -> str | None:
         try:
             return str(self.rule.rule_data["conditions"][0]["run_state"]["trigger_successive"])
         except Exception:

--- a/common/actions/send_email_action.py
+++ b/common/actions/send_email_action.py
@@ -1,7 +1,6 @@
 __all__ = ["SendEmailAction"]
 import logging
 from dataclasses import asdict
-from typing import Optional
 from uuid import UUID
 
 from peewee import DoesNotExist
@@ -22,7 +21,7 @@ class SendEmailAction(BaseAction):
     required_arguments = {"recipients", "template"}
     requires_action_template = True
 
-    def _run(self, event: EVENT_TYPE, rule: Rule, journey_id: Optional[UUID]) -> ActionResult:
+    def _run(self, event: EVENT_TYPE, rule: Rule, journey_id: UUID | None) -> ActionResult:
         try:
             context = self._get_data_points(event, rule, journey_id)
         except Exception as e:
@@ -41,7 +40,7 @@ class SendEmailAction(BaseAction):
             return ActionResult(True, response, None)
 
     def _get_data_points(
-        self, event: EVENT_TYPE, rule: Rule, journey_id: Optional[UUID]
+        self, event: EVENT_TYPE, rule: Rule, journey_id: UUID | None
     ) -> dict | AgentStatusChangeDataPoints:
         """
         Get the data points to be used in the email template

--- a/common/actions/webhook_action.py
+++ b/common/actions/webhook_action.py
@@ -1,7 +1,7 @@
 __all__ = ["WebhookAction"]
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Union
 from collections.abc import Mapping
 from uuid import UUID
 
@@ -44,7 +44,7 @@ def format_data(data: Union[None, list, dict, str], data_points: Mapping) -> Any
 class WebhookAction(BaseAction):
     required_arguments = {"url", "method"}
 
-    def _run(self, event: EVENT_TYPE, rule: Rule, _: Optional[UUID]) -> ActionResult:
+    def _run(self, event: EVENT_TYPE, rule: Rule, _: UUID | None) -> ActionResult:
         data_points: Mapping
         match event:
             case RunAlert() | InstanceAlert():
@@ -67,7 +67,7 @@ class WebhookAction(BaseAction):
             return ActionResult(False, None, e)
         return ActionResult(True, {"status_code": response.status_code}, None)
 
-    def _parse_headers(self, data_points: Mapping) -> Optional[dict[str, str]]:
+    def _parse_headers(self, data_points: Mapping) -> dict[str, str] | None:
         if headers := self.arguments.get("headers"):
             return {h["key"]: format_data(h["value"], data_points) for h in headers}
         else:

--- a/common/api/base_view.py
+++ b/common/api/base_view.py
@@ -4,7 +4,7 @@ import json
 import logging
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Optional
+from typing import Any
 
 from flask import g, request
 from flask.typing import ResponseReturnValue
@@ -22,7 +22,7 @@ LOG = logging.getLogger(__name__)
 @dataclass
 class Permission:
     entity_attribute: str
-    role: Optional[str] = None
+    role: str | None = None
     methods: tuple[str, ...] = ("GET", "PUT", "POST", "PATCH", "DELETE")
 
     def __call__(self, *methods: str) -> Permission:
@@ -48,7 +48,7 @@ class BaseView(MethodView):
     """
 
     @property
-    def user(self) -> Optional[User]:
+    def user(self) -> User | None:
         """Return the currently authenticated user."""
         return getattr(g, "user", None)
 
@@ -61,12 +61,12 @@ class BaseView(MethodView):
             return []
 
     @property
-    def claims(self) -> Optional[User]:
+    def claims(self) -> User | None:
         """Return the currently authenticated token."""
         return getattr(g, "claims", None)
 
     @property
-    def project(self) -> Optional[Project]:
+    def project(self) -> Project | None:
         return getattr(g, "project", None)
 
     @property

--- a/common/api/flask_ext/authentication/common.py
+++ b/common/api/flask_ext/authentication/common.py
@@ -1,7 +1,6 @@
 __all__ = ["get_domain", "BaseAuthPlugin", "validate_authentication"]
 import logging
 import re
-from typing import Optional
 from urllib.parse import urlparse
 
 from flask import current_app, g, request
@@ -16,10 +15,10 @@ LOG = logging.getLogger(__name__)
 
 class BaseAuthPlugin(BaseExtension):
     header_name: str = NotImplemented
-    header_prefix: Optional[str] = None
+    header_prefix: str | None = None
 
     @classmethod
-    def get_header_data(cls) -> Optional[str]:
+    def get_header_data(cls) -> str | None:
         auth_data = request.headers.get(cls.header_name, None)
         if auth_data and cls.header_prefix:
             if match := re.match(rf"^{cls.header_prefix}\s+(.*)\s*$", auth_data):

--- a/common/api/flask_ext/authentication/jwt_plugin.py
+++ b/common/api/flask_ext/authentication/jwt_plugin.py
@@ -1,7 +1,7 @@
 __all__ = ["JWTAuth"]
 import logging
-from datetime import datetime, timedelta, timezone
-from typing import Optional, cast
+from datetime import datetime, timedelta, UTC
+from typing import cast
 from collections.abc import Callable
 
 from flask import current_app, g, request
@@ -25,7 +25,7 @@ def get_token_expiration(claims: JWT_CLAIMS) -> datetime:
     except KeyError as ke:
         raise ValueError("Token claims missing 'exp' key") from ke
     try:
-        return datetime.fromtimestamp(cast(float | int, exp_timestamp), tz=timezone.utc)
+        return datetime.fromtimestamp(cast(float | int, exp_timestamp), tz=UTC)
     except Exception as e:
         raise ValueError(f"Unable to parse expiration from '{claims['exp']}'") from e
 
@@ -64,7 +64,7 @@ class JWTAuth(BaseAuthPlugin):
         except Exception as e:
             raise Unauthorized("Invalid authentication token") from e
 
-        if get_token_expiration(claims) < datetime.now(timezone.utc):
+        if get_token_expiration(claims) < datetime.now(UTC):
             LOG.error("JWT token expired")
             raise Unauthorized("Invalid authentication token")
 
@@ -96,7 +96,7 @@ class JWTAuth(BaseAuthPlugin):
         return decoded_token
 
     @classmethod
-    def log_user_in(cls, user: User, logout_callback: Optional[str] = None, claims: Optional[JWT_CLAIMS] = None) -> str:
+    def log_user_in(cls, user: User, logout_callback: str | None = None, claims: JWT_CLAIMS | None = None) -> str:
         claims = claims or {}
 
         if logout_callback:
@@ -106,7 +106,7 @@ class JWTAuth(BaseAuthPlugin):
                 raise ValueError(f"Logout callback '{logout_callback}' is not registered.")
 
         if "exp" not in claims:
-            claims["exp"] = (datetime.now(timezone.utc) + cls.default_jwt_expiration).timestamp()
+            claims["exp"] = (datetime.now(UTC) + cls.default_jwt_expiration).timestamp()
 
         claims["user_id"] = str(user.id)
         claims["company_id"] = str(user.primary_company_id)

--- a/common/api/flask_ext/base_extension.py
+++ b/common/api/flask_ext/base_extension.py
@@ -1,12 +1,11 @@
 __all__ = ["BaseExtension"]
-from typing import Optional
 
 from flask import Flask
 from flask.typing import AfterRequestCallable, AppOrBlueprintKey, BeforeRequestCallable
 
 
 class BaseExtension:
-    def __init__(self, app: Optional[Flask] = None) -> None:
+    def __init__(self, app: Flask | None = None) -> None:
         if app is not None:
             self.app = app
             self.init_app()

--- a/common/api/flask_ext/config.py
+++ b/common/api/flask_ext/config.py
@@ -1,6 +1,5 @@
 __all__ = ["Config"]
 import os
-from typing import Optional
 
 from flask import Flask
 
@@ -16,7 +15,7 @@ class Config:
     then the configuration will load "foo.bar.production"
     """
 
-    def __init__(self, app: Optional[Flask] = None, config_module: str = ""):
+    def __init__(self, app: Flask | None = None, config_module: str = ""):
         if not config_module:
             raise ValueError("You must provide a 'config_module' to the Config extension")
         self.app = app

--- a/common/api/flask_ext/cors.py
+++ b/common/api/flask_ext/cors.py
@@ -2,7 +2,6 @@ __all__ = ["CORS"]
 from conf import settings
 from http import HTTPStatus
 from fnmatch import fnmatch
-from typing import Optional
 from urllib.parse import urlparse
 
 from flask import Flask, Response, make_response, request
@@ -24,13 +23,13 @@ CORS_HEADERS: dict[str, str] = {
 
 
 class CORS(BaseExtension):
-    def __init__(self, app: Optional[Flask] = None, allowed_methods: Optional[list[str]] = None):
+    def __init__(self, app: Flask | None = None, allowed_methods: list[str] | None = None):
         allowed_methods = allowed_methods or []
         self.allowed_methods = ", ".join(allowed_methods + ["OPTIONS"]).upper()
         super().__init__(app)
 
     @staticmethod
-    def make_preflight_response() -> Optional[Response]:
+    def make_preflight_response() -> Response | None:
         if request.method == "OPTIONS":
             # When request.endpoint isn't populated it means that the URL didn't match any registered view. For this
             # case we abort and issue a 404

--- a/common/api/request_parsing.py
+++ b/common/api/request_parsing.py
@@ -1,7 +1,7 @@
 __all__ = ["get_bool_param", "no_body_allowed", "str_to_bool", "get_origin_domain"]
 
 from functools import wraps
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable, Iterable
 from urllib.parse import urlparse
 
@@ -33,10 +33,10 @@ def str_to_bool(value: str, param_name: str) -> bool:
     elif case_insensitive_value == "false":
         return False
     else:
-        raise ValidationError({param_name: ("Expected 'true' or 'false'. Instead received " f"'{value}'.")})
+        raise ValidationError({param_name: (f"Expected 'true' or 'false'. Instead received '{value}'.")})
 
 
-def no_body_allowed(func: Optional[Callable] = None, /, methods: Iterable[str] = SAFE_HTTP_METHODS) -> Callable:
+def no_body_allowed(func: Callable | None = None, /, methods: Iterable[str] = SAFE_HTTP_METHODS) -> Callable:
     """
     Decorator to be used on MethodView functions if the function does not allow a request body to be passed.
 
@@ -58,7 +58,7 @@ def no_body_allowed(func: Optional[Callable] = None, /, methods: Iterable[str] =
         return decorator
 
 
-def get_origin_domain() -> Optional[str]:
+def get_origin_domain() -> str | None:
     if (source_url := request.headers.get("Origin")) is not None:
         try:
             return urlparse(source_url).netloc or None

--- a/common/api/search_view.py
+++ b/common/api/search_view.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from flask import Blueprint, Response, request
 from flask.typing import RouteCallable
@@ -12,7 +12,7 @@ SEARCH_ENDPOINT: str = "search"
 
 
 class SearchView(BaseView):
-    args_from_post: Optional[MultiDict] = None
+    args_from_post: MultiDict | None = None
     request_body_schema: type[Schema]
 
     def post(self, *args: Any, **kwargs: Any) -> Response:

--- a/common/apscheduler_extensions.py
+++ b/common/apscheduler_extensions.py
@@ -3,7 +3,6 @@ __all__ = ["DelayedTrigger", "validate_cron_expression", "get_crontab_trigger_ti
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Optional
 from collections.abc import Generator
 from zoneinfo import ZoneInfo
 
@@ -36,10 +35,10 @@ class DelayedTrigger(BaseTrigger):
         self.trigger = trigger
         self.delay = delay
 
-    def get_next_fire_time(self, previous_fire_time: Optional[datetime], now: datetime) -> Optional[datetime]:
+    def get_next_fire_time(self, previous_fire_time: datetime | None, now: datetime) -> datetime | None:
         if previous_fire_time:
             previous_fire_time -= self.delay
-        next_fire_time: Optional[datetime] = self.trigger.get_next_fire_time(previous_fire_time, now)
+        next_fire_time: datetime | None = self.trigger.get_next_fire_time(previous_fire_time, now)
         return next_fire_time + self.delay if next_fire_time else None
 
     def __str__(self) -> str:
@@ -109,7 +108,7 @@ def fix_weekdays(expression: str) -> str:
 
 
 def get_crontab_trigger_times(
-    crontab: str, timezone: ZoneInfo, start_range: datetime, end_range: Optional[datetime] = None
+    crontab: str, timezone: ZoneInfo, start_range: datetime, end_range: datetime | None = None
 ) -> Generator[datetime, None, None]:
     """
     Generate the crontab trigger times for the given time range.

--- a/common/auth/keys/service_key.py
+++ b/common/auth/keys/service_key.py
@@ -1,8 +1,8 @@
 import logging
 from base64 import b64encode
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from typing import NamedTuple, Optional
+from datetime import datetime, timedelta, UTC
+from typing import NamedTuple
 from uuid import uuid4
 
 from peewee import DoesNotExist
@@ -31,15 +31,15 @@ def generate_key(
     *,
     project: Project,
     allowed_services: list[str],
-    name: Optional[str] = None,
-    description: Optional[str] = None,
+    name: str | None = None,
+    description: str | None = None,
     expiration_days: int = DEFAULT_EXPIRY_DAYS,
 ) -> KeyPair:
     """Generate a new Service Account key for the given service name."""
     passphrase = generate_passphrase()
     salt = str(uuid4())
     passphrase_hash = hash_value(value=passphrase, salt=salt)
-    expiry = datetime.now(timezone.utc) + timedelta(days=expiration_days)
+    expiry = datetime.now(UTC) + timedelta(days=expiration_days)
     digest = create_digest(iterations=HASH_ITERATIONS, salt=salt, passphrase_hash=passphrase_hash)
 
     # Give the key a pretty unique name if none provided (Name only has to be unique per-project so this should safe)

--- a/common/datetime_utils.py
+++ b/common/datetime_utils.py
@@ -1,12 +1,12 @@
 __all__ = ["datetime_formatted", "datetime_iso8601", "to_utc_aware"]
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 
 # Although datetimes in Events are tz aware they only contains the raw offset
 # after being marshmallow serialized. Since the tz name is desired astimezone
 # is used for strftime to return the name.
 def to_utc_aware(dt: datetime) -> datetime:
-    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
 
 
 def datetime_formatted(dt: datetime) -> str:
@@ -28,5 +28,5 @@ def datetime_to_timestamp(dt: datetime) -> float:
 
 def timestamp_to_datetime(timestamp: float) -> datetime:
     """Convert a timestamp to a datetime object in UTC time."""
-    dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    dt = datetime.fromtimestamp(timestamp, tz=UTC)
     return dt

--- a/common/decorators.py
+++ b/common/decorators.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Optional, TypeVar, cast
+from typing import Any, TypeVar, cast
 from collections.abc import Callable
 
 PropertyType = TypeVar("PropertyType")
 
 
-class cached_property(Generic[PropertyType]):
+class cached_property[PropertyType]:
     """
     A `property` decorator that caches the value on the instance.
 
@@ -47,7 +47,7 @@ class cached_property(Generic[PropertyType]):
 
     """
 
-    _name: Optional[str] = None
+    _name: str | None = None
 
     def __init__(self, f: Callable[[Any], PropertyType]) -> None:
         self.func = f
@@ -59,7 +59,7 @@ class cached_property(Generic[PropertyType]):
         elif name != self._name:
             raise TypeError(f"Cannot assign the same instance to two names ({self._name} and {name}).")
 
-    def __get__(self, inst: object, cls: Optional[Any] = None) -> PropertyType:
+    def __get__(self, inst: object, cls: Any | None = None) -> PropertyType:
         """
         Retrieve the value from instance, stashing the result in inst.__dict__
 

--- a/common/entities/alert.py
+++ b/common/entities/alert.py
@@ -2,7 +2,6 @@ __all__ = ["RunAlert", "InstanceAlert", "AlertLevel", "InstanceAlertsComponents"
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 
 from peewee import CharField, CompositeKey, ForeignKeyField
 from playhouse.mysql_ext import JSONField
@@ -63,7 +62,7 @@ class AlertBase(BaseEntity, AuditUpdateTimeEntityMixin):
     level = EnumStrField(AlertLevel, null=False, max_length=50)
 
     @property
-    def expected_start_time(self) -> Optional[datetime]:
+    def expected_start_time(self) -> datetime | None:
         """If the alert has expected_start_time in it's details dict, return it as a datetime object."""
         timestamp = self.details.get("expected_start_time", None)
         if timestamp:
@@ -76,7 +75,7 @@ class AlertBase(BaseEntity, AuditUpdateTimeEntityMixin):
             return None
 
     @expected_start_time.setter
-    def expected_start_time(self, dt_obj: Optional[datetime]) -> None:
+    def expected_start_time(self, dt_obj: datetime | None) -> None:
         """Set the expected_start_time value (converts to timestamp in details dict)."""
         if dt_obj is None:
             self.details.pop("expected_start_time", None)
@@ -85,7 +84,7 @@ class AlertBase(BaseEntity, AuditUpdateTimeEntityMixin):
             self.details["expected_start_time"] = timestamp
 
     @property
-    def expected_end_time(self) -> Optional[datetime]:
+    def expected_end_time(self) -> datetime | None:
         """If the alert has expected_end_time in it's details dict, return it as a datetime object."""
         timestamp = self.details.get("expected_end_time", None)
         if timestamp:
@@ -98,7 +97,7 @@ class AlertBase(BaseEntity, AuditUpdateTimeEntityMixin):
             return None
 
     @expected_end_time.setter
-    def expected_end_time(self, dt_obj: Optional[datetime]) -> None:
+    def expected_end_time(self, dt_obj: datetime | None) -> None:
         """Set the expected_end_time value (converts to timestamp in details dict)."""
         if dt_obj is None:
             self.details.pop("expected_end_time", None)

--- a/common/entities/authentication.py
+++ b/common/entities/authentication.py
@@ -1,6 +1,6 @@
 __all__ = ["ApiKey", "Service", "ServiceAccountKey"]
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from enum import Enum
 from uuid import uuid4
 
@@ -24,7 +24,7 @@ class ApiKey(Model):
     user = ForeignKeyField(User, backref="api_keys", on_delete="CASCADE", null=False, index=True)
 
     def is_expired(self) -> bool:
-        if datetime.now(timezone.utc) > self.expiry:
+        if datetime.now(UTC) > self.expiry:
             return True
         else:
             return False
@@ -59,7 +59,7 @@ class ServiceAccountKey(Model):
         # If no expiration date is set, the key's duration is unlimited
         if not self.expiry:
             return False
-        if datetime.now(timezone.utc) > self.expiry:
+        if datetime.now(UTC) > self.expiry:
             return True
         else:
             return False

--- a/common/entities/base_entity.py
+++ b/common/entities/base_entity.py
@@ -1,6 +1,6 @@
 __all__ = ["ActivableEntityMixin", "AuditEntityMixin", "AuditUpdateTimeEntityMixin", "BaseEntity", "BaseModel", "DB"]
 
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Any
 from uuid import uuid4
 
@@ -53,5 +53,5 @@ class AuditUpdateTimeEntityMixin(Model):
 
     @classmethod
     def update(cls, *args: Any, **kwargs: Any) -> Any:
-        kwargs["updated_on"] = datetime.utcnow().replace(tzinfo=timezone.utc)
+        kwargs["updated_on"] = datetime.utcnow().replace(tzinfo=UTC)
         return super().update(*args, **kwargs)

--- a/common/entities/company.py
+++ b/common/entities/company.py
@@ -1,6 +1,5 @@
 __all__ = ["Company"]
 
-from typing import Optional
 
 from peewee import CharField, ForeignKeyField
 
@@ -13,5 +12,5 @@ class Company(BaseEntity, AuditEntityMixin):
     name = CharField(unique=True, null=False)
 
     @property
-    def parent(self) -> Optional[ForeignKeyField]:
+    def parent(self) -> ForeignKeyField | None:
         return None

--- a/common/entities/component_meta.py
+++ b/common/entities/component_meta.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 from peewee import Field, ForeignKeyField, ModelBase, ModelSelect, ModelUpdate
 
@@ -144,7 +144,7 @@ class ComplexComponentMeta(ModelBase):
             component.save(force_insert=True)
             return component
 
-        def save(self: BaseModel, force_insert: bool = False, only: Optional[object] = None) -> Union[bool, int]:
+        def save(self: BaseModel, force_insert: bool = False, only: object | None = None) -> Union[bool, int]:
             ret = 0
             if not force_insert and self.component:
                 ret += self.component.save(only=only) or 0

--- a/common/entities/dataset_operation.py
+++ b/common/entities/dataset_operation.py
@@ -13,8 +13,8 @@ from .instance import InstanceSet
 
 
 class DatasetOperationType(Enum):
-    READ: str = "READ"
-    WRITE: str = "WRITE"
+    READ = "READ"
+    WRITE = "WRITE"
 
 
 class DatasetOperation(BaseEntity):

--- a/common/entities/upcoming_instance.py
+++ b/common/entities/upcoming_instance.py
@@ -1,7 +1,6 @@
 __all__ = ["UpcomingInstance"]
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 from common.entities.journey import Journey
 
@@ -9,5 +8,5 @@ from common.entities.journey import Journey
 @dataclass
 class UpcomingInstance:
     journey: Journey
-    expected_start_time: Optional[datetime] = None
-    expected_end_time: Optional[datetime] = None
+    expected_start_time: datetime | None = None
+    expected_end_time: datetime | None = None

--- a/common/entity_services/component_service.py
+++ b/common/entity_services/component_service.py
@@ -2,7 +2,6 @@ __all__ = ["ComponentService"]
 
 from datetime import datetime
 from itertools import cycle
-from typing import Optional
 from collections.abc import Generator
 
 from peewee import Select
@@ -31,7 +30,7 @@ class ComponentService:
 
     @classmethod
     def get_or_create_active_instances(
-        cls, component: Component, start_time: Optional[datetime] = None
+        cls, component: Component, start_time: datetime | None = None
     ) -> Generator[tuple[bool, Instance], None, None]:
         """
         Retrieves active Instances for a given component. Create active Instances when a Journey does not have one.

--- a/common/entity_services/helpers/filter_rules.py
+++ b/common/entity_services/helpers/filter_rules.py
@@ -73,7 +73,7 @@ class ParamConfig:
     func: Callable
 
 
-def _date_or_none(params: MultiDict, field_name: str) -> Optional[datetime]:
+def _date_or_none(params: MultiDict, field_name: str) -> datetime | None:
     if date := params.get(field_name):
         try:
             return arrow.get(date).datetime
@@ -82,7 +82,7 @@ def _date_or_none(params: MultiDict, field_name: str) -> Optional[datetime]:
     return None
 
 
-def _str_to_bool(params: MultiDict, field_name: str) -> Optional[bool]:
+def _str_to_bool(params: MultiDict, field_name: str) -> bool | None:
     if (value := params.get(field_name)) is None:
         return None
     return str_to_bool(value, field_name)
@@ -132,29 +132,28 @@ class Filters:
     Extend by specifying the wanted attributes and how to unpack them in from_params.
     """
 
-    active: Optional[bool] = None
+    active: bool | None = None
     component_ids: list[str] = field(default_factory=list)
     component_types: list[str] = field(default_factory=list)
-    date_range_end: Optional[datetime] = None
-    date_range_start: Optional[datetime] = None
-    end_range: Optional[datetime] = None
-    end_range_begin: Optional[datetime] = None
-    end_range_end: Optional[datetime] = None
+    date_range_end: datetime | None = None
+    date_range_start: datetime | None = None
+    end_range: datetime | None = None
+    end_range_begin: datetime | None = None
+    end_range_end: datetime | None = None
     event_ids: list[str] = field(default_factory=list)
     event_types: list[str] = field(default_factory=list)
     instance_ids: list[str] = field(default_factory=list)
     journey_ids: list[str] = field(default_factory=list)
     journey_names: list[str] = field(default_factory=list)
-    key: Optional[str] = None
+    key: str | None = None
     levels: list[str] = field(default_factory=list)
     pipeline_keys: list[str] = field(default_factory=list)
     project_ids: list[str] = field(default_factory=list)
     run_ids: list[str] = field(default_factory=list)
     run_keys: list[str] = field(default_factory=list)
-    search: Optional[str] = None
-    start_range: Optional[datetime] = None
-    start_range_begin: Optional[datetime] = None
-    start_range_end: Optional[datetime] = None
+    start_range: datetime | None = None
+    start_range_begin: datetime | None = None
+    start_range_end: datetime | None = None
     statuses: list[str] = field(default_factory=list)
     task_ids: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
@@ -169,9 +168,7 @@ class Filters:
         return False
 
     @staticmethod
-    def validate_time_range(
-        range_begin: Optional[datetime], range_end: Optional[datetime], range_begin_name: str
-    ) -> None:
+    def validate_time_range(range_begin: datetime | None, range_end: datetime | None, range_begin_name: str) -> None:
         if range_begin is None or range_end is None:
             return None
         if range_begin >= range_end:
@@ -334,7 +331,6 @@ class ProjectEventFilters(Filters):
                 TASK_ID_QUERY_NAME,
                 DATE_RANGE_START_QUERY_NAME,
                 DATE_RANGE_END_QUERY_NAME,
-                SEARCH_QUERY_NAME,
             ],
         )
 

--- a/common/entity_services/helpers/list_rules.py
+++ b/common/entity_services/helpers/list_rules.py
@@ -4,7 +4,7 @@ __all__ = ["ListRules", "Page", "SortOrder", "DEFAULT_PAGE", "DEFAULT_COUNT", "L
 from dataclasses import dataclass
 from enum import Enum as std_Enum
 from enum import auto
-from typing import Generic, Optional, TypeVar
+from typing import TypeVar
 from collections.abc import Generator
 
 from marshmallow import EXCLUDE, Schema
@@ -36,7 +36,7 @@ class ListSchema(Schema):
 
 
 @dataclass
-class Page(Generic[T]):
+class Page[T]:
     """
     Useful for returning results from the service layer to get paginated results
     but also receive the total objects without pagination.
@@ -83,7 +83,7 @@ class ListRules:
     page: int = DEFAULT_PAGE
     count: int = DEFAULT_COUNT
     sort: SortOrder = SortOrder.ASC
-    search: Optional[str] = None
+    search: str | None = None
 
     @classmethod
     def from_params_without_search(cls, params: MultiDict) -> ListRules:

--- a/common/entity_services/instance_service.py
+++ b/common/entity_services/instance_service.py
@@ -2,7 +2,6 @@ __all__ = ["InstanceService"]
 
 from collections import Counter, defaultdict
 from datetime import datetime
-from typing import Optional
 from collections.abc import Iterable
 from uuid import UUID
 
@@ -163,11 +162,11 @@ class InstanceService:
     def get_instance_run_counts(
         instance: UUID | Instance,
         *,
-        include_run_statuses: Optional[Iterable[str]] = None,
-        exclude_run_statuses: Optional[Iterable[str]] = None,
-        journey: Optional[UUID] = None,
-        pipelines: Optional[Iterable[UUID]] = None,
-        end_before: Optional[datetime] = None,
+        include_run_statuses: Iterable[str] | None = None,
+        exclude_run_statuses: Iterable[str] | None = None,
+        journey: UUID | None = None,
+        pipelines: Iterable[UUID] | None = None,
+        end_before: datetime | None = None,
     ) -> dict[UUID, int]:
         """
         Return a dict of pipelines with the corresponding run count per pipeline.

--- a/common/entity_services/journey_service.py
+++ b/common/entity_services/journey_service.py
@@ -2,7 +2,6 @@ __all__ = ["JourneyService"]
 
 import logging
 from fnmatch import fnmatch
-from typing import Optional
 from uuid import UUID
 
 from common.entities import DB, Action, Company, Component, Journey, JourneyDagEdge, Organization, Project, Rule
@@ -20,7 +19,7 @@ class JourneyService:
         return Page[Rule].get_paginated_results(query, Rule.created_on, list_rules)
 
     @staticmethod
-    def get_action_by_implementation(journey_id: UUID, action_impl: str) -> Optional[Action]:
+    def get_action_by_implementation(journey_id: UUID, action_impl: str) -> Action | None:
         """
         Fetches an Action entity given a Journey ID and the action implementation.
 

--- a/common/entity_services/pipeline_service.py
+++ b/common/entity_services/pipeline_service.py
@@ -1,6 +1,5 @@
 __all__ = ["PipelineService"]
 import logging
-from typing import Optional
 
 from common.entities import Pipeline
 
@@ -9,6 +8,6 @@ LOG = logging.getLogger(__name__)
 
 class PipelineService:
     @staticmethod
-    def get_by_key_and_project(pipeline_key: Optional[str], project_id: str) -> Pipeline:
+    def get_by_key_and_project(pipeline_key: str | None, project_id: str) -> Pipeline:
         pipeline: Pipeline = Pipeline.get(Pipeline.key == pipeline_key, Pipeline.project == project_id)
         return pipeline

--- a/common/entity_services/project_service.py
+++ b/common/entity_services/project_service.py
@@ -2,7 +2,7 @@ __all__ = ["ProjectService"]
 
 from functools import reduce
 from operator import or_
-from typing import Any, Optional
+from typing import Any
 
 from peewee import PREFETCH_TYPE, Value, fn, prefetch, DoesNotExist
 
@@ -107,7 +107,7 @@ class ProjectService:
 
     @staticmethod
     def get_runs_with_rules(
-        project_id: Optional[str], pipeline_ids: list[str], rules: ListRules, filters: RunFilters
+        project_id: str | None, pipeline_ids: list[str], rules: ListRules, filters: RunFilters
     ) -> Page[Run]:
         start_dt = fn.COALESCE(Run.start_time, Run.expected_start_time)
         query = Run.select(Run, start_dt.alias("start_dt")).distinct()
@@ -154,7 +154,7 @@ class ProjectService:
 
     @staticmethod
     def get_instances_with_rules(
-        rules: ListRules, filters: Filters, project_ids: list[str], company_id: Optional[str] = None
+        rules: ListRules, filters: Filters, project_ids: list[str], company_id: str | None = None
     ) -> Page[Instance]:
         memberships = [Journey.project.in_(project_ids)] if project_ids else []
         if company_id:
@@ -211,7 +211,7 @@ class ProjectService:
         return Page[Instance](results=results, total=query.count())
 
     @staticmethod
-    def get_journeys_with_rules(project_id: str, rules: ListRules, component_id: Optional[str] = None) -> Page[Journey]:
+    def get_journeys_with_rules(project_id: str, rules: ListRules, component_id: str | None = None) -> Page[Journey]:
         base_query = Journey.project == project_id
         if rules.search is not None:
             base_query &= Journey.name ** f"%{rules.search}%"

--- a/common/entity_services/test_outcome_service.py
+++ b/common/entity_services/test_outcome_service.py
@@ -1,6 +1,5 @@
 __all__ = ["TestOutcomeService"]
 
-from typing import Optional
 from uuid import UUID
 
 from peewee import SqliteDatabase
@@ -17,9 +16,9 @@ class TestOutcomeService:
         *,
         event: TestOutcomesEvent,
         component_id: UUID,
-        instance_set_id: Optional[UUID] = None,
-        run_id: Optional[UUID] = None,
-        task_id: Optional[UUID] = None,
+        instance_set_id: UUID | None = None,
+        run_id: UUID | None = None,
+        task_id: UUID | None = None,
     ) -> None:
         test_outcomes = []
         test_outcome_integrations = []
@@ -65,7 +64,7 @@ class TestOutcomeService:
                     )
 
         # Using the recursive lookup avoids having to check for None on optional values up the whole chain
-        testgen_dataset: Optional[TestgenDataset] = getattr_recursive(
+        testgen_dataset: TestgenDataset | None = getattr_recursive(
             event, "component_integrations__integrations__testgen", None
         )
 

--- a/common/entity_services/upcoming_instance_service.py
+++ b/common/entity_services/upcoming_instance_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from heapq import merge
 from operator import itemgetter
-from typing import Optional, cast
+from typing import cast
 from collections.abc import Generator
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -65,7 +65,7 @@ def _collect_journey_schedules(
 def _get_instance_times(
     schedules: JourneySchedules,
     start_time: datetime,
-    end_time: Optional[datetime],
+    end_time: datetime | None,
 ) -> Generator[tuple[datetime, bool], None, None]:
     """
     Generate a sequence of expected instance start and end times from the given schedules
@@ -96,8 +96,8 @@ class UpcomingInstanceService:
     def get_upcoming_instances_with_rules(
         rules: ListRules,
         filters: UpcomingInstanceFilters,
-        project_id: Optional[UUID] = None,
-        company_id: Optional[UUID] = None,
+        project_id: UUID | None = None,
+        company_id: UUID | None = None,
     ) -> list[UpcomingInstance]:
         assert filters.start_range is not None
         memberships = []
@@ -159,8 +159,8 @@ class UpcomingInstanceService:
     def get_upcoming_instances(
         journey: Journey,
         start_time: datetime,
-        end_time: Optional[datetime] = None,
-        schedules: Optional[JourneySchedules] = None,
+        end_time: datetime | None = None,
+        schedules: JourneySchedules | None = None,
     ) -> Generator[UpcomingInstance, None, None]:
         """
         Get upcoming instances for the given journey

--- a/common/entity_services/user_service.py
+++ b/common/entity_services/user_service.py
@@ -1,14 +1,10 @@
-from typing import Optional
-
 from common.entities import User
 from common.entity_services.helpers import ListRules, Page
 
 
 class UserService:
     @staticmethod
-    def list_with_rules(
-        rules: ListRules, company_id: Optional[str] = None, name_filter: Optional[str] = None
-    ) -> Page[User]:
+    def list_with_rules(rules: ListRules, company_id: str | None = None, name_filter: str | None = None) -> Page[User]:
         query = User.select()
         if company_id:
             query = query.where(User.primary_company_id == company_id)

--- a/common/events/base.py
+++ b/common/events/base.py
@@ -12,10 +12,9 @@ __all__ = [
 ]
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from enum import Enum as std_Enum
 from functools import partial
-from typing import Optional
 from uuid import UUID
 from uuid import UUID as std_UUID
 from uuid import uuid4
@@ -44,14 +43,14 @@ class ProjectMixin:
 
 @dataclass(kw_only=True)
 class ComponentMixin:
-    component_id: Optional[UUID] = None
-    component_type: Optional[ComponentType] = None
+    component_id: UUID | None = None
+    component_type: ComponentType | None = None
 
 
 @dataclass(kw_only=True)
 class BatchPipelineMixin:
-    batch_pipeline_id: Optional[UUID] = None
-    run_id: Optional[UUID] = None
+    batch_pipeline_id: UUID | None = None
+    run_id: UUID | None = None
 
     @cached_property
     def batch_pipeline(self) -> Pipeline:
@@ -66,13 +65,13 @@ class BatchPipelineMixin:
 
 @dataclass(kw_only=True)
 class RunMixin:
-    run_id: Optional[UUID] = None
+    run_id: UUID | None = None
 
 
 @dataclass(kw_only=True)
 class TaskMixin:
-    task_id: Optional[UUID] = None
-    run_task_id: Optional[UUID] = None
+    task_id: UUID | None = None
+    run_task_id: UUID | None = None
 
     @cached_property
     def task(self) -> Task:
@@ -109,11 +108,11 @@ class JourneysMixin:
 
 @dataclass(kw_only=True)
 class JourneyMixin:
-    journey_id: Optional[UUID] = None
-    instance_id: Optional[UUID] = None
+    journey_id: UUID | None = None
+    instance_id: UUID | None = None
 
 
 @dataclass(kw_only=True)
 class EventBaseMixin:
     event_id: UUID = field(default_factory=uuid4)
-    created_timestamp: datetime = field(default_factory=partial(datetime.now, tz=timezone.utc))
+    created_timestamp: datetime = field(default_factory=partial(datetime.now, tz=UTC))

--- a/common/events/converters.py
+++ b/common/events/converters.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, fields
-from typing import Optional, cast
+from typing import cast
 
 from common.entities import ComponentType, RunStatus
 from common.entities.event import ApiEventType
@@ -29,7 +29,7 @@ class ConvertToV1(EventHandlerBase):
             "payload_keys": event.event_payload.payload_keys,
         }
 
-    def _extract_batch_attributes(self, batch: Optional[v2.BatchPipelineData]) -> dict:
+    def _extract_batch_attributes(self, batch: v2.BatchPipelineData | None) -> dict:
         data = {
             "run_name": batch.run_name if batch else None,
             "run_key": batch.run_key if batch else None,
@@ -40,7 +40,7 @@ class ConvertToV1(EventHandlerBase):
             data["component_tool"] = batch.details.tool
         return data
 
-    def _extract_dataset_attributes(self, dataset: Optional[v2.DatasetData]) -> dict:
+    def _extract_dataset_attributes(self, dataset: v2.DatasetData | None) -> dict:
         data = {
             "dataset_key": dataset.dataset_key if dataset else None,
             "dataset_name": dataset.details.name if dataset and dataset.details else None,
@@ -49,7 +49,7 @@ class ConvertToV1(EventHandlerBase):
             data["component_tool"] = dataset.details.tool
         return data
 
-    def _extract_server_attributes(self, server: Optional[v2.ServerData]) -> dict:
+    def _extract_server_attributes(self, server: v2.ServerData | None) -> dict:
         data = {
             "server_key": server.server_key if server else None,
             "server_name": server.details.name if server and server.details else None,
@@ -58,7 +58,7 @@ class ConvertToV1(EventHandlerBase):
             data["component_tool"] = server.details.tool
         return data
 
-    def _extract_stream_attributes(self, stream: Optional[v2.StreamData]) -> dict:
+    def _extract_stream_attributes(self, stream: v2.StreamData | None) -> dict:
         data = {
             "stream_key": stream.stream_key if stream else None,
             "stream_name": stream.details.name if stream and stream.details else None,
@@ -69,10 +69,10 @@ class ConvertToV1(EventHandlerBase):
 
     def _extract_component_data(
         self,
-        batch: Optional[v2.BatchPipelineData],
-        dataset: Optional[v2.DatasetData],
-        server: Optional[v2.ServerData],
-        stream: Optional[v2.StreamData],
+        batch: v2.BatchPipelineData | None,
+        dataset: v2.DatasetData | None,
+        server: v2.ServerData | None,
+        stream: v2.StreamData | None,
     ) -> dict:
         data = {
             **self._extract_batch_attributes(batch),
@@ -84,7 +84,7 @@ class ConvertToV1(EventHandlerBase):
             data["component_tool"] = None
         return data
 
-    def _extract_task_attributes(self, event: EventV2, batch: Optional[v2.BatchPipelineData]) -> dict:
+    def _extract_task_attributes(self, event: EventV2, batch: v2.BatchPipelineData | None) -> dict:
         return {
             "task_key": batch.task_key if batch else None,
             "task_name": batch.task_name if batch else None,
@@ -116,8 +116,8 @@ class ConvertToV1(EventHandlerBase):
         )
 
     def _extract_test_outcome_item_integrations(
-        self, integrations: Optional[dict]
-    ) -> Optional[v1.TestOutcomeItemIntegrations]:
+        self, integrations: dict | None
+    ) -> v1.TestOutcomeItemIntegrations | None:
         if integrations is None:
             return None
         return v1.TestOutcomeItemIntegrations(testgen=self._extract_testgen_item(integrations["testgen"]))
@@ -142,8 +142,8 @@ class ConvertToV1(EventHandlerBase):
         )
 
     def _extract_testgen_table_group_config(
-        self, table_group_configuration: Optional[dict]
-    ) -> Optional[v1.TestgenTableGroupV1]:
+        self, table_group_configuration: dict | None
+    ) -> v1.TestgenTableGroupV1 | None:
         if table_group_configuration is None:
             return None
         return v1.TestgenTableGroupV1(
@@ -167,7 +167,7 @@ class ConvertToV1(EventHandlerBase):
 
     def _extract_component_integrations(
         self, component: v2.TestGenComponentData
-    ) -> Optional[v1.TestGenTestOutcomeIntegrationComponent]:
+    ) -> v1.TestGenTestOutcomeIntegrationComponent | None:
         integrations = next(c for f in fields(component) if (c := getattr(component, f.name, None))).integrations
         if integrations is None:
             return None
@@ -301,7 +301,7 @@ class ConvertToV2(EventHandlerBase):
             "version": event.version,
         }
 
-    def _extract_batch_pipeline_data(self, event: Event) -> Optional[v2.BatchPipelineData]:
+    def _extract_batch_pipeline_data(self, event: Event) -> v2.BatchPipelineData | None:
         new_component_data = (
             v2.NewComponentData(name=event.pipeline_name, tool=event.component_tool)
             if event.pipeline_name or event.component_tool
@@ -319,9 +319,7 @@ class ConvertToV2(EventHandlerBase):
         else:
             return None
 
-    def _extract_testgen_batch_pipeline_data(
-        self, event: v1.TestOutcomesEvent
-    ) -> Optional[v2.TestGenBatchPipelineData]:
+    def _extract_testgen_batch_pipeline_data(self, event: v1.TestOutcomesEvent) -> v2.TestGenBatchPipelineData | None:
         if data := self._extract_batch_pipeline_data(event):
             return v2.TestGenBatchPipelineData(
                 batch_key=data.batch_key,
@@ -334,7 +332,7 @@ class ConvertToV2(EventHandlerBase):
             )
         return None
 
-    def _extract_testgen_dataset_data(self, event: v1.TestOutcomesEvent) -> Optional[v2.TestGenDatasetData]:
+    def _extract_testgen_dataset_data(self, event: v1.TestOutcomesEvent) -> v2.TestGenDatasetData | None:
         if data := self._extract_dataset_data(event):
             return v2.TestGenDatasetData(
                 dataset_key=data.dataset_key,
@@ -343,7 +341,7 @@ class ConvertToV2(EventHandlerBase):
             )
         return None
 
-    def _extract_testgen_stream_data(self, event: v1.TestOutcomesEvent) -> Optional[v2.TestGenStreamData]:
+    def _extract_testgen_stream_data(self, event: v1.TestOutcomesEvent) -> v2.TestGenStreamData | None:
         if data := self._extract_stream_data(event):
             return v2.TestGenStreamData(
                 stream_key=data.stream_key,
@@ -352,7 +350,7 @@ class ConvertToV2(EventHandlerBase):
             )
         return None
 
-    def _extract_testgen_server_data(self, event: v1.TestOutcomesEvent) -> Optional[v2.TestGenServerData]:
+    def _extract_testgen_server_data(self, event: v1.TestOutcomesEvent) -> v2.TestGenServerData | None:
         if data := self._extract_server_data(event):
             return v2.TestGenServerData(
                 server_key=data.server_key,
@@ -361,7 +359,7 @@ class ConvertToV2(EventHandlerBase):
             )
         return None
 
-    def _extract_dataset_data(self, event: Event) -> Optional[v2.DatasetData]:
+    def _extract_dataset_data(self, event: Event) -> v2.DatasetData | None:
         new_component_data = (
             v2.NewComponentData(name=event.dataset_name, tool=event.component_tool)
             if event.dataset_name or event.component_tool
@@ -372,7 +370,7 @@ class ConvertToV2(EventHandlerBase):
         else:
             return None
 
-    def _extract_stream_data(self, event: Event) -> Optional[v2.StreamData]:
+    def _extract_stream_data(self, event: Event) -> v2.StreamData | None:
         new_component_data = (
             v2.NewComponentData(name=event.stream_name, tool=event.component_tool)
             if event.stream_name or event.component_tool
@@ -386,7 +384,7 @@ class ConvertToV2(EventHandlerBase):
         else:
             return None
 
-    def _extract_server_data(self, event: Event) -> Optional[v2.ServerData]:
+    def _extract_server_data(self, event: Event) -> v2.ServerData | None:
         new_component_data = (
             v2.NewComponentData(name=event.server_name, tool=event.component_tool)
             if event.server_name or event.component_tool
@@ -439,8 +437,8 @@ class ConvertToV2(EventHandlerBase):
         )
 
     def _extract_test_outcome_item_integrations(
-        self, integrations: Optional[dict]
-    ) -> Optional[v2.TestOutcomeItemIntegrations]:
+        self, integrations: dict | None
+    ) -> v2.TestOutcomeItemIntegrations | None:
         if integrations is None:
             return None
         return v2.TestOutcomeItemIntegrations(testgen=self._extract_testgen_item(integrations["testgen"]))
@@ -465,8 +463,8 @@ class ConvertToV2(EventHandlerBase):
         )
 
     def _extract_testgen_table_group_config(
-        self, table_group_configuration: Optional[dict]
-    ) -> Optional[v2.TestgenTableGroupV1]:
+        self, table_group_configuration: dict | None
+    ) -> v2.TestgenTableGroupV1 | None:
         if table_group_configuration is None:
             return None
         return v2.TestgenTableGroupV1(
@@ -485,7 +483,7 @@ class ConvertToV2(EventHandlerBase):
 
     def _extract_testgen_integration_componenet(
         self, event: v1.TestOutcomesEvent
-    ) -> Optional[v2.TestGenTestOutcomeIntegrations]:
+    ) -> v2.TestGenTestOutcomeIntegrations | None:
         if i := event.component_integrations:
             return v2.TestGenTestOutcomeIntegrations(
                 testgen=self._extract_testgen_integrations(asdict(i.integrations.testgen)),

--- a/common/events/internal/alert.py
+++ b/common/events/internal/alert.py
@@ -4,7 +4,6 @@ __all__ = [
 ]
 
 from dataclasses import dataclass
-from typing import Optional
 from uuid import UUID
 
 from common.decorators import cached_property
@@ -20,7 +19,7 @@ from common.events.base import BatchPipelineMixin, EventBaseMixin, JourneyMixin,
 class AlertBase:
     alert_id: UUID
     level: AlertLevel
-    description: Optional[str]
+    description: str | None
 
 
 @dataclass(kw_only=True)

--- a/common/events/internal/scheduled_event.py
+++ b/common/events/internal/scheduled_event.py
@@ -2,7 +2,6 @@ __all__ = ["ScheduledEvent", "BatchPipelineStatusPlatformEvent"]
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 from uuid import UUID
 
 from common.events.base import ComponentMixin
@@ -19,7 +18,7 @@ class ScheduledEvent(ComponentMixin):
     schedule_id: UUID
     schedule_type: ScheduleType
     schedule_timestamp: datetime
-    schedule_margin: Optional[datetime] = None
+    schedule_margin: datetime | None = None
 
     @property
     def partition_identifier(self) -> str:

--- a/common/events/v1/dataset_operation_event.py
+++ b/common/events/v1/dataset_operation_event.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 __all__ = ["DatasetOperationSchema", "DatasetOperationApiSchema", "DatasetOperationEvent", "DatasetOperationType"]
 
 from dataclasses import dataclass
-from typing import Optional
 
 from marshmallow import Schema, ValidationError, validates_schema
 from marshmallow.fields import Str
@@ -55,7 +54,7 @@ class DatasetOperationEvent(Event):
     __api_schema__ = DatasetOperationApiSchema
 
     operation: str
-    path: Optional[str] = None
+    path: str | None = None
 
     def accept(self, handler: EventHandlerBase) -> bool:
         return handler.handle_dataset_operation(self)

--- a/common/events/v1/event.py
+++ b/common/events/v1/event.py
@@ -4,8 +4,7 @@ __all__ = ["Event", "EventInterface", "EVENT_ATTRIBUTES"]
 
 import logging
 from dataclasses import InitVar, dataclass, field
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import datetime, UTC
 from uuid import UUID, uuid4
 
 from common.decorators import cached_property
@@ -72,35 +71,35 @@ class Event(EventInterface):
     this to define your own Event to ensure your events have all the expected fields.
     """
 
-    pipeline_key: Optional[str]
+    pipeline_key: str | None
     source: str
     event_id: UUID
     event_timestamp: datetime
     received_timestamp: datetime
     metadata: dict[str, object]
     event_type: str
-    run_name: Optional[str]
-    run_key: Optional[str]
-    component_tool: Optional[str]
-    project_id: Optional[UUID]
-    run_id: Optional[UUID]
-    pipeline_id: Optional[UUID]
-    task_id: Optional[UUID]
-    task_name: Optional[str]
-    task_key: Optional[str]
-    run_task_id: Optional[UUID]
-    external_url: Optional[str]
-    pipeline_name: Optional[str]
+    run_name: str | None
+    run_key: str | None
+    component_tool: str | None
+    project_id: UUID | None
+    run_id: UUID | None
+    pipeline_id: UUID | None
+    task_id: UUID | None
+    task_name: str | None
+    task_key: str | None
+    run_task_id: UUID | None
+    external_url: str | None
+    pipeline_name: str | None
     instances: list[InstanceRef]
-    dataset_id: Optional[UUID]
-    dataset_key: Optional[str]
-    dataset_name: Optional[str]
-    server_id: Optional[UUID]
-    server_key: Optional[str]
-    server_name: Optional[str]
-    stream_id: Optional[UUID]
-    stream_key: Optional[str]
-    stream_name: Optional[str]
+    dataset_id: UUID | None
+    dataset_key: str | None
+    dataset_name: str | None
+    server_id: UUID | None
+    server_key: str | None
+    server_name: str | None
+    stream_id: UUID | None
+    stream_key: str | None
+    stream_name: str | None
     payload_keys: list[str]
     version: EventVersion
 
@@ -131,7 +130,7 @@ class Event(EventInterface):
         # At a glance, we could have these defaulted by the schema. However, the spec says that if timestamp is not
         # defined, it _must_ be matched to the received time. Setting it in the schema would generate very tiny
         # differences in time.
-        current_time = str(datetime.now(timezone.utc))
+        current_time = str(datetime.now(UTC))
         if "event_timestamp" not in event_body:
             event_body["event_timestamp"] = current_time
         event_body["received_timestamp"] = current_time
@@ -215,7 +214,7 @@ class Event(EventInterface):
     @cached_property
     def component_key_details(self) -> EventComponentDetails:
         if not (key := next((attr for attr in EVENT_ATTRIBUTES.keys() if getattr(self, attr, None) is not None), None)):
-            LOG.error(f"Event component key details cannot be parsed from the event information provided: " f"{self}")
+            LOG.error(f"Event component key details cannot be parsed from the event information provided: {self}")
             raise ValueError("Event component key details cannot be parsed.")
         return EVENT_ATTRIBUTES[key]
 
@@ -227,7 +226,7 @@ class Event(EventInterface):
         return key
 
     @property
-    def component_id(self) -> Optional[UUID]:
+    def component_id(self) -> UUID | None:
         return getattr(self, self.component_key_details.component_id, None)
 
     @component_id.setter
@@ -239,7 +238,7 @@ class Event(EventInterface):
         setattr(self, self.component_key_details.component_id, value)
 
     @property
-    def component_name(self) -> Optional[str]:
+    def component_name(self) -> str | None:
         return getattr(self, self.component_key_details.component_name, None)
 
     @property

--- a/common/events/v1/event_schemas.py
+++ b/common/events/v1/event_schemas.py
@@ -1,7 +1,7 @@
 __all__ = ["EventSchemaInterface", "EventApiSchema", "EventSchema"]
 
 import json
-from datetime import timezone
+from datetime import UTC
 from typing import Any, Union
 
 from marshmallow import Schema, ValidationError, post_dump, post_load, pre_load, validates_schema
@@ -176,7 +176,7 @@ class EventApiSchema(EventSchemaInterface):
     )
     event_timestamp = AwareDateTime(
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={
             "description": (
                 "Optional. An ISO8601 timestamp that describes when the event occurred. If no timezone "
@@ -251,7 +251,7 @@ class EventSchema(EventApiSchema):
     received_timestamp = AwareDateTime(
         format="iso",
         required=True,
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={"description": "An ISO timestamp that the Event Ingestion API applies when it receives the event."},
     )
     # This is the source of the message.

--- a/common/events/v1/test_outcomes_event.py
+++ b/common/events/v1/test_outcomes_event.py
@@ -18,11 +18,11 @@ __all__ = [
 ]
 
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from decimal import Decimal as std_decimal
 from enum import Enum as std_Enum
 from enum import IntEnum as std_IntEnum
-from typing import Any, Optional, Union
+from typing import Any, Union
 from uuid import UUID as std_UUID
 
 from marshmallow import Schema, ValidationError, post_load, validates_schema
@@ -100,7 +100,7 @@ class TestgenItem:
     test_suite: str
     version: int
     test_parameters: list[TestgenItemTestParameters]
-    columns: Optional[list[str]] = None
+    columns: list[str] | None = None
 
 
 class TestgenItemSchema(Schema):
@@ -163,8 +163,8 @@ class TestOutcomeItemIntegrationsSchema(Schema):
 @dataclass
 class TestgenTable:
     include_list: list[str]
-    include_pattern: Optional[str] = None
-    exclude_pattern: Optional[str] = None
+    include_pattern: str | None = None
+    exclude_pattern: str | None = None
 
 
 class TestgenTableSchema(Schema):
@@ -217,9 +217,9 @@ class TestgenTableSchema(Schema):
 class TestgenTableGroupV1:
     group_id: std_UUID
     project_code: str
-    uses_sampling: Optional[bool] = None
-    sample_percentage: Optional[str] = None
-    sample_minimum_count: Optional[int] = None
+    uses_sampling: bool | None = None
+    sample_percentage: str | None = None
+    sample_minimum_count: int | None = None
 
 
 class TestgenTableGroupV1Schema(Schema):
@@ -263,8 +263,8 @@ class TestgenDataset:
     database_name: str
     connection_name: str
     tables: TestgenTable
-    schema: Optional[str] = None
-    table_group_configuration: Optional[TestgenTableGroupV1] = None
+    schema: str | None = None
+    table_group_configuration: TestgenTableGroupV1 | None = None
 
 
 class TestgenDatasetSchema(Schema):
@@ -346,19 +346,19 @@ class TestOutcomeItem:
     name: str
     status: str
     description: str = ""
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
-    metadata: Optional[dict[str, Any]] = None
-    metric_value: Optional[Decimal] = None
-    metric_name: Optional[str] = None
-    metric_description: Optional[str] = None
-    min_threshold: Optional[Decimal] = None
-    max_threshold: Optional[Decimal] = None
-    integrations: Optional[TestOutcomeItemIntegrations] = None
-    dimensions: Optional[list[str]] = None
-    result: Optional[str] = None
-    type: Optional[str] = None
-    key: Optional[str] = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    metadata: dict[str, Any] | None = None
+    metric_value: Decimal | None = None
+    metric_name: str | None = None
+    metric_description: str | None = None
+    min_threshold: Decimal | None = None
+    max_threshold: Decimal | None = None
+    integrations: TestOutcomeItemIntegrations | None = None
+    dimensions: list[str] | None = None
+    result: str | None = None
+    type: str | None = None
+    key: str | None = None
 
 
 # region Schemas
@@ -373,8 +373,7 @@ class TestOutcomeItemSchema(Schema):
         enum=TestStatuses,
         metadata={
             "description": (
-                "Required. The test status to be applied. Can set the status for both tests in runs and "
-                "tests in tasks."
+                "Required. The test status to be applied. Can set the status for both tests in runs and tests in tasks."
             )
         },
     )
@@ -384,13 +383,13 @@ class TestOutcomeItemSchema(Schema):
     )
     start_time = AwareDateTime(
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         allow_none=True,
         metadata={"description": "An ISO timestamp of when the test execution started."},
     )
     end_time = AwareDateTime(
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         allow_none=True,
         metadata={"description": "An ISO timestamp of when the test execution ended."},
     )
@@ -530,7 +529,7 @@ class TestOutcomesEvent(Event):
     """Represents the single result of a test."""
 
     test_outcomes: list[TestOutcomeItem]
-    component_integrations: Optional[TestGenTestOutcomeIntegrationComponent] = None
+    component_integrations: TestGenTestOutcomeIntegrationComponent | None = None
 
     __schema__ = TestOutcomesSchema
     __api_schema__ = TestOutcomesApiSchema

--- a/common/events/v2/base.py
+++ b/common/events/v2/base.py
@@ -7,8 +7,7 @@ __all__ = [
 
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import datetime, UTC
 
 from marshmallow import Schema
 from marshmallow.fields import UUID, AwareDateTime, Dict, List, Str, Url
@@ -24,9 +23,9 @@ from ..event_handler import EventHandlerBase
 
 @dataclass
 class BasePayload:
-    event_timestamp: Optional[datetime]
+    event_timestamp: datetime | None
     metadata: dict[str, object]
-    external_url: Optional[str]
+    external_url: str | None
     payload_keys: list[str]
 
 
@@ -38,7 +37,7 @@ class BasePayloadSchema(Schema):
     event_timestamp = AwareDateTime(
         load_default=None,
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={
             "description": (
                 "An ISO8601 timestamp that describes when the event occurred. "

--- a/common/events/v2/component_data.py
+++ b/common/events/v2/component_data.py
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from marshmallow import Schema, ValidationError, post_load, validates_schema
 from marshmallow.fields import Nested, Str
@@ -28,44 +28,44 @@ from common.schemas.validators import not_empty
 
 @dataclass
 class NewComponentData:
-    name: Optional[str]
-    tool: Optional[str]
+    name: str | None
+    tool: str | None
 
 
 @dataclass
 class BatchPipelineData:
     batch_key: str
     run_key: str
-    run_name: Optional[str]
-    task_key: Optional[str]
-    task_name: Optional[str]
-    details: Optional[NewComponentData]
+    run_name: str | None
+    task_key: str | None
+    task_name: str | None
+    details: NewComponentData | None
 
 
 @dataclass
 class DatasetData:
     dataset_key: str
-    details: Optional[NewComponentData]
+    details: NewComponentData | None
 
 
 @dataclass
 class ServerData:
     server_key: str
-    details: Optional[NewComponentData]
+    details: NewComponentData | None
 
 
 @dataclass
 class StreamData:
     stream_key: str
-    details: Optional[NewComponentData]
+    details: NewComponentData | None
 
 
 @dataclass
 class ComponentData:
-    batch_pipeline: Optional[BatchPipelineData]
-    stream: Optional[StreamData]
-    dataset: Optional[DatasetData]
-    server: Optional[ServerData]
+    batch_pipeline: BatchPipelineData | None
+    stream: StreamData | None
+    dataset: DatasetData | None
+    server: ServerData | None
 
 
 class NewComponentDataSchema(Schema):

--- a/common/events/v2/dataset_operation.py
+++ b/common/events/v2/dataset_operation.py
@@ -7,7 +7,7 @@ __all__ = [
 
 from dataclasses import dataclass
 from enum import Enum as std_Enum
-from typing import Any, Optional
+from typing import Any
 
 from marshmallow import post_load
 from marshmallow.fields import Enum, Nested, Str
@@ -28,7 +28,7 @@ class DatasetOperationType(std_Enum):
 class DatasetOperation(BasePayload):
     dataset_component: DatasetData
     operation: DatasetOperationType
-    path: Optional[str]
+    path: str | None
 
 
 class DatasetOperationSchema(BasePayloadSchema):

--- a/common/events/v2/test_outcomes.py
+++ b/common/events/v2/test_outcomes.py
@@ -13,10 +13,10 @@ __all__ = [
 
 from dataclasses import dataclass
 from dataclasses import fields as dc_fields
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from decimal import Decimal as std_Decimal
 from enum import Enum as std_Enum
-from typing import Any, Optional
+from typing import Any
 
 from marshmallow import Schema, ValidationError, post_load, validates_schema
 from marshmallow.fields import AwareDateTime, Decimal, Dict, Enum, List, Nested, Str
@@ -56,23 +56,23 @@ class TestOutcomeItem:
     status: TestStatus
     description: str
     metadata: dict[str, Any]
-    start_time: Optional[datetime]
-    end_time: Optional[datetime]
-    metric_value: Optional[std_Decimal]
-    metric_name: Optional[str]
-    metric_description: Optional[str]
-    metric_min_threshold: Optional[std_Decimal]
-    metric_max_threshold: Optional[std_Decimal]
-    integrations: Optional[TestOutcomeItemIntegrations]
-    dimensions: Optional[list[str]]
-    result: Optional[str]
-    type: Optional[str]
-    key: Optional[str]
+    start_time: datetime | None
+    end_time: datetime | None
+    metric_value: std_Decimal | None
+    metric_name: str | None
+    metric_description: str | None
+    metric_min_threshold: std_Decimal | None
+    metric_max_threshold: std_Decimal | None
+    integrations: TestOutcomeItemIntegrations | None
+    dimensions: list[str] | None
+    result: str | None
+    type: str | None
+    key: str | None
 
 
 @dataclass
 class TestGenIntegrations:
-    integrations: Optional[TestGenTestOutcomeIntegrations]
+    integrations: TestGenTestOutcomeIntegrations | None
 
 
 @dataclass
@@ -93,10 +93,10 @@ class TestGenStreamData(StreamData, TestGenIntegrations): ...
 
 @dataclass
 class TestGenComponentData:
-    batch_pipeline: Optional[TestGenBatchPipelineData]
-    stream: Optional[TestGenStreamData]
-    dataset: Optional[TestGenDatasetData]
-    server: Optional[TestGenServerData]
+    batch_pipeline: TestGenBatchPipelineData | None
+    stream: TestGenStreamData | None
+    dataset: TestGenDatasetData | None
+    server: TestGenServerData | None
 
 
 @dataclass
@@ -125,8 +125,7 @@ class TestOutcomeItemSchema(Schema):
         enum=TestStatus,
         metadata={
             "description": (
-                "Required. The test status to be applied. Can set the status for both tests in runs and "
-                "tests in tasks."
+                "Required. The test status to be applied. Can set the status for both tests in runs and tests in tasks."
             )
         },
     )
@@ -144,13 +143,13 @@ class TestOutcomeItemSchema(Schema):
     )
     start_time = AwareDateTime(
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         load_default=None,
         metadata={"description": "An ISO timestamp of when the test execution started."},
     )
     end_time = AwareDateTime(
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         load_default=None,
         metadata={"description": "An ISO timestamp of when the test execution ended."},
     )

--- a/common/events/v2/testgen.py
+++ b/common/events/v2/testgen.py
@@ -14,7 +14,7 @@ __all__ = [
 from dataclasses import asdict, dataclass
 from decimal import Decimal as std_Decimal
 from enum import IntEnum
-from typing import Any, Optional, Union
+from typing import Any, Union
 from uuid import UUID as std_UUID
 
 from marshmallow import Schema, ValidationError, post_load, validates_schema
@@ -60,7 +60,7 @@ class TestgenItem:
     test_suite: str
     version: TestgenIntegrationVersions
     test_parameters: list[TestgenItemTestParameters]
-    columns: Optional[list[str]]
+    columns: list[str] | None
 
 
 @dataclass
@@ -71,17 +71,17 @@ class TestOutcomeItemIntegrations:
 @dataclass
 class TestgenTable:
     include_list: list[str]
-    include_pattern: Optional[str]
-    exclude_pattern: Optional[str]
+    include_pattern: str | None
+    exclude_pattern: str | None
 
 
 @dataclass
 class TestgenTableGroupV1:
     group_id: std_UUID
     project_code: str
-    uses_sampling: Optional[bool]
-    sample_percentage: Optional[str]
-    sample_minimum_count: Optional[int]
+    uses_sampling: bool | None
+    sample_percentage: str | None
+    sample_minimum_count: int | None
 
 
 @dataclass
@@ -90,8 +90,8 @@ class TestgenDataset:
     database_name: str
     connection_name: str
     tables: TestgenTable
-    schema: Optional[str]
-    table_group_configuration: Optional[TestgenTableGroupV1]
+    schema: str | None
+    table_group_configuration: TestgenTableGroupV1 | None
 
 
 @dataclass

--- a/common/kafka/consumer.py
+++ b/common/kafka/consumer.py
@@ -3,7 +3,7 @@ __all__ = ["KafkaConsumer", "KafkaTransactionalConsumer"]
 import logging
 import signal
 from types import FrameType
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Iterator
 
 from confluent_kafka import Consumer, Message
@@ -49,7 +49,7 @@ class GracefulKiller:
         signal.signal(signal.SIGTERM, GracefulKiller.exit_gracefully)
 
     @staticmethod
-    def exit_gracefully(sig_num: int, frame: Optional[FrameType]) -> Any:
+    def exit_gracefully(sig_num: int, frame: FrameType | None) -> Any:
         LOG.info(f"Signal {sig_num} received, attempting to exit gracefully. Use SIGKILL to terminate immediately.")
         GracefulKiller.should_exit = True
 
@@ -152,9 +152,9 @@ class KafkaConsumer:
         except Exception as e:
             raise ConsumerCommitError from e
 
-    def poll(self) -> Optional[KafkaMessage]:
+    def poll(self) -> KafkaMessage | None:
         try:
-            msg: Optional[Message] = self.consumer.poll(CONSUMER_POLL_PERIOD_SECS)
+            msg: Message | None = self.consumer.poll(CONSUMER_POLL_PERIOD_SECS)
         except DisconnectedConsumerError:
             raise
         except Exception as ex:

--- a/common/kafka/message.py
+++ b/common/kafka/message.py
@@ -1,12 +1,12 @@
 __all__ = ["KafkaMessage"]
 from dataclasses import dataclass
-from typing import Generic, Optional, TypeVar
+from typing import TypeVar
 
 T = TypeVar("T")
 
 
 @dataclass(frozen=True, kw_only=True)
-class KafkaMessage(Generic[T]):
+class KafkaMessage[T]:
     """
     A generic Kafka message
 
@@ -19,4 +19,4 @@ class KafkaMessage(Generic[T]):
     partition: int
     offset: int
     headers: dict
-    key: Optional[str] = None
+    key: str | None = None

--- a/common/kafka/producer.py
+++ b/common/kafka/producer.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from contextlib import contextmanager
 from types import TracebackType
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable, Generator
 
 from confluent_kafka import KafkaError, KafkaException, Message, Producer
@@ -88,7 +88,7 @@ class KafkaProducer:
         return self
 
     def __exit__(
-        self, exc_type: Optional[type[BaseException]], exc_value: Optional[BaseException], tb: Optional[TracebackType]
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, tb: TracebackType | None
     ) -> None:
         self.disconnect()
 
@@ -105,7 +105,7 @@ class KafkaProducer:
         metadata = self.producer.list_topics(topic=topic.name, timeout=timeout)
         return len(metadata.topics[topic.name].partitions) > 0
 
-    def produce(self, topic: Topic, event: Any, callback: Optional[Callable] = None) -> None:
+    def produce(self, topic: Topic, event: Any, callback: Callable | None = None) -> None:
         def delivery_report(err: KafkaError, message: Message) -> None:
             """Called once for each message produced to indicate delivery result. Triggered by poll() or flush()."""
             if err is not None:
@@ -149,7 +149,7 @@ class KafkaTransactionalProducer(KafkaProducer):
 
     """
 
-    def __init__(self, config: dict, tx_consumer: Optional[KafkaTransactionalConsumer] = None) -> None:
+    def __init__(self, config: dict, tx_consumer: KafkaTransactionalConsumer | None = None) -> None:
         if PRODUCER_TX_MANDATORY_SETTINGS.keys() & config.keys():
             raise ProducerConfigurationError(
                 f"Local configuration cannot override any of {PRODUCER_TX_MANDATORY_SETTINGS.keys()}"

--- a/common/kafka/topic.py
+++ b/common/kafka/topic.py
@@ -9,7 +9,7 @@ __all__ = [
 
 import json
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Optional, Protocol
+from typing import Any, NamedTuple, Protocol
 
 from confluent_kafka import Message
 
@@ -29,7 +29,7 @@ class ProduceMessageArgs(NamedTuple):
     value: bytes
     topic: str
     headers: dict[str, str]
-    key: Optional[str] = None
+    key: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         d = {
@@ -44,7 +44,7 @@ class ProduceMessageArgs(NamedTuple):
         return d
 
 
-def _get_headers_as_dict(headers: Optional[list[tuple[str, bytes]]]) -> dict[str, str]:
+def _get_headers_as_dict(headers: list[tuple[str, bytes]] | None) -> dict[str, str]:
     return {k: v.decode("utf-8") for k, v in headers or {}}
 
 

--- a/common/logging/json_logging.py
+++ b/common/logging/json_logging.py
@@ -1,12 +1,12 @@
 __all__ = ["JsonFormatter"]
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from json import dumps
 
 from common.json_encoder import JsonExtendedEncoder
 
-UTC = timezone.utc
+UTC = UTC
 
 
 class JsonFormatter(logging.Formatter):

--- a/common/messagepack.py
+++ b/common/messagepack.py
@@ -9,7 +9,7 @@ from importlib import import_module
 from io import BytesIO
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from types import MappingProxyType
-from typing import Any, BinaryIO, Optional, TextIO, Union, cast
+from typing import Any, BinaryIO, TextIO, Union, cast
 from collections.abc import Callable
 from uuid import UUID
 
@@ -261,7 +261,7 @@ def decode_ext(code: int, data: bytes) -> object:
             return ExtType(code, data)
 
 
-def dump(value: object, flo: FLO, hook: Optional[Callable] = None) -> None:
+def dump(value: object, flo: FLO, hook: Callable | None = None) -> None:
     """
     Serialize as msgpack and write the result to a file-like-object.
 
@@ -281,7 +281,7 @@ def dump(value: object, flo: FLO, hook: Optional[Callable] = None) -> None:
     )
 
 
-def dumps(value: object, hook: Optional[Callable] = None) -> bytes:
+def dumps(value: object, hook: Callable | None = None) -> bytes:
     """
     Serialize object to msgpack and return resulting messagepack bytes.
 
@@ -295,7 +295,7 @@ def dumps(value: object, hook: Optional[Callable] = None) -> bytes:
     return result
 
 
-def load(flo: FLO, object_hook: Optional[Callable] = None) -> Any:
+def load(flo: FLO, object_hook: Callable | None = None) -> Any:
     """
     Deserialize a msgpack file-like-object.
 
@@ -317,7 +317,7 @@ def load(flo: FLO, object_hook: Optional[Callable] = None) -> Any:
     return result
 
 
-def loads(stream: bytes, object_hook: Optional[Callable] = None) -> Any:
+def loads(stream: bytes, object_hook: Callable | None = None) -> Any:
     """
     Deserialize msgpack bytes
 

--- a/common/model.py
+++ b/common/model.py
@@ -7,7 +7,6 @@ import pkgutil
 from contextlib import suppress
 from importlib import import_module
 from types import ModuleType
-from typing import Optional
 
 from peewee import Database, Model, SchemaManager
 
@@ -17,7 +16,7 @@ from common.entities import Component
 LOG = logging.getLogger(__name__)
 
 
-def walk(module: Optional[ModuleType] = None) -> dict[str, Model]:
+def walk(module: ModuleType | None = None) -> dict[str, Model]:
     """
     Recursively scans a module for all PeeWee model classes. Defaults to `common.entities` but can scan any module.
 

--- a/common/peewee_extensions/fixtures.py
+++ b/common/peewee_extensions/fixtures.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from functools import cache
 from graphlib import CycleError, TopologicalSorter
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 # TODO: When we move to Python 3.11+ we can switch to importing tomlib and we can remove the tomli requirement from
@@ -57,7 +57,7 @@ def generate_table_map() -> dict[str, Model]:
     return {x._meta.table_name: x for x in model_map.values()}
 
 
-def dump_results(results: ModelSelect, *, requires_id: Optional[UUID] = None) -> str:
+def dump_results(results: ModelSelect, *, requires_id: UUID | None = None) -> str:
     """Given Peewee query results, generate a fixture dump."""
     model_class = results.model
     rows = []

--- a/common/predicate_engine/compilers/utils.py
+++ b/common/predicate_engine/compilers/utils.py
@@ -17,4 +17,4 @@ def prefetch_query(*args: SelectQuery | type[Model]) -> Callable[..., Iterable]:
         result: list[Model] = query.prefetch(*_queries, prefetch_type=PREFETCH_TYPE.JOIN)
         return result
 
-    return partial(_prefetch_query, _queries=args)
+    return partial(_prefetch_query, _queries=list(args))

--- a/common/schemas/fields/cron_expr_str.py
+++ b/common/schemas/fields/cron_expr_str.py
@@ -1,6 +1,6 @@
 __all__ = ["CronExpressionStr"]
 
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Mapping
 
 from marshmallow import ValidationError
@@ -16,7 +16,7 @@ class CronExpressionStr(Str):
     It validates against what ApScheduler's CronTrigger expects.
     """
 
-    def _deserialize(self, value: Any, attr: Optional[str], data: Optional[Mapping[str, Any]], **kwargs: object) -> Any:
+    def _deserialize(self, value: Any, attr: str | None, data: Mapping[str, Any] | None, **kwargs: object) -> Any:
         str_value = super(Str, self)._deserialize(value, attr, data, **kwargs)
         if errors := validate_cron_expression(str_value):
             raise ValidationError(" ".join(errors))

--- a/common/schemas/fields/enum_str.py
+++ b/common/schemas/fields/enum_str.py
@@ -1,7 +1,7 @@
 __all__ = ["EnumStr"]
 
 from enum import Enum, EnumMeta
-from typing import Any, Optional, Union, cast
+from typing import Any, Union, cast
 from collections.abc import Iterable
 
 from marshmallow.utils import ensure_text_type
@@ -30,7 +30,7 @@ class EnumStr(NormalizedStr):
 
         super().__init__(validate=OneOf(allowed_values), **kwargs)  # type: ignore[arg-type]
 
-    def _serialize(self, value: Any, attr: Optional[str], obj: Any, **kwargs: object) -> Optional[str]:
+    def _serialize(self, value: Any, attr: str | None, obj: Any, **kwargs: object) -> str | None:
         if value is None:
             return None
         if isinstance(value, Enum):

--- a/common/schemas/fields/normalized_str.py
+++ b/common/schemas/fields/normalized_str.py
@@ -1,6 +1,6 @@
 __all__ = ["NormalizedStr", "strip_upper_underscore"]
 
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable, Mapping
 
 from marshmallow.fields import Str
@@ -23,13 +23,13 @@ class NormalizedStr(Str):
         self.normalizer_func = normalizer
         super().__init__(**kwargs)
 
-    def _serialize(self, value: Any, attr: Optional[str], obj: Any, **kwargs: object) -> Optional[str]:
+    def _serialize(self, value: Any, attr: str | None, obj: Any, **kwargs: object) -> str | None:
         if value is None:
             return None
         str_field = ensure_text_type(value)
         return self.normalizer_func(str_field)
 
-    def _deserialize(self, value: Any, attr: Optional[str], data: Optional[Mapping[str, Any]], **kwargs: object) -> Any:
+    def _deserialize(self, value: Any, attr: str | None, data: Mapping[str, Any] | None, **kwargs: object) -> Any:
         if not isinstance(value, str | bytes):
             raise self.make_error("invalid")
         try:

--- a/common/schemas/fields/zoneinfo.py
+++ b/common/schemas/fields/zoneinfo.py
@@ -1,7 +1,7 @@
 __all__ = ["ZoneInfo"]
 
 import zoneinfo
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Mapping
 
 from marshmallow.fields import Str
@@ -16,7 +16,7 @@ class ZoneInfo(Str):
 
     default_error_messages = {"invalid_timezone": INVALID_TIMEZONE}
 
-    def _deserialize(self, value: Any, attr: Optional[str], data: Optional[Mapping[str, Any]], **kwargs: object) -> Any:
+    def _deserialize(self, value: Any, attr: str | None, data: Mapping[str, Any] | None, **kwargs: object) -> Any:
         str_value = super(Str, self)._deserialize(value, attr, data, **kwargs)
         # Given ZoneInfo accepts a filesystem type as its constructor argument and we don't want to accept paths as
         # values for ZoneInfo fields, we validate the input before trying to build the ZoneInfo object

--- a/common/schemas/filter_schemas.py
+++ b/common/schemas/filter_schemas.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timezone
-from typing import Any, Optional, Union
+from datetime import datetime, UTC
+from typing import Any, Union
 
 from marshmallow import EXCLUDE, Schema, ValidationError, pre_load, validates_schema
 from marshmallow.fields import UUID, AwareDateTime, Boolean, Enum, List, Str
@@ -11,7 +11,7 @@ from common.schemas.validators import not_empty
 
 class FiltersSchema(Schema):
     def validate_time_range(
-        self, range_begin: Optional[datetime], range_end: Optional[datetime], range_begin_name: str
+        self, range_begin: datetime | None, range_end: datetime | None, range_begin_name: str
     ) -> None:
         if range_begin is None or range_end is None:
             return None
@@ -43,7 +43,7 @@ class InstanceFiltersSchema(FiltersSchema):
     start_range_begin = AwareDateTime(
         allow_none=True,
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={
             "description": "Optional. An ISO8601 datetime. If specified, The result will only include instances with a "
             "start_time field equal or past the given datetime. May be specified with start_range_end "
@@ -53,7 +53,7 @@ class InstanceFiltersSchema(FiltersSchema):
     start_range_end = AwareDateTime(
         allow_none=True,
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={
             "description": "Optional. An ISO8601 datetime. If specified, the result will only contain instances with a "
             "start_time field before the given datetime. May be specified with start_range_begin to create "
@@ -63,7 +63,7 @@ class InstanceFiltersSchema(FiltersSchema):
     end_range_begin = AwareDateTime(
         allow_none=True,
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={
             "description": "Optional. An ISO8601 datetime. If specified, The result will only include instances with an "
             "end_time field equal or past the given datetime. May be specified with end_range_end to create a range."
@@ -72,7 +72,7 @@ class InstanceFiltersSchema(FiltersSchema):
     end_range_end = AwareDateTime(
         allow_none=True,
         format="iso",
-        default_timezone=timezone.utc,
+        default_timezone=UTC,
         metadata={
             "description": "Optional. An ISO8601 datetime. If specified, The result will only include instances with an "
             "end_time field before the given datetime. May be specified with end_range_begin to create a range."

--- a/common/schemas/validators/regexp.py
+++ b/common/schemas/validators/regexp.py
@@ -1,7 +1,6 @@
 __all__ = ["IsRegexp"]
 
 import re
-from typing import Optional
 
 from marshmallow import ValidationError
 from marshmallow.validate import Validator
@@ -14,7 +13,7 @@ class IsRegexp(Validator):
 
     message_invalid = "Invalid regular expression"
 
-    def __init__(self, *, error: Optional[str] = None) -> None:
+    def __init__(self, *, error: str | None = None) -> None:
         self.error: str = error or self.message_invalid
 
     def __call__(self, value: str) -> str:

--- a/common/tests/integration/entities/test_alerts.py
+++ b/common/tests/integration/entities/test_alerts.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 
@@ -94,7 +94,7 @@ def test_run_alert_expected_start_time_get(pipeline_run):
     run_alert = RunAlert(run=pipeline_run, name="A", description="A", level=AlertLevel.ERROR, type="invalid")
     assert run_alert.expected_start_time is None
     run_alert.details["expected_start_time"] = 1123922544.0
-    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=timezone.utc) == run_alert.expected_start_time
+    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=UTC) == run_alert.expected_start_time
 
 
 @pytest.mark.integration
@@ -117,7 +117,7 @@ def test_run_alert_expected_end_time_get(pipeline_run):
     run_alert = RunAlert(run=pipeline_run, name="A", description="A", level=AlertLevel.ERROR, type="invalid")
     assert run_alert.expected_end_time is None  # No details have been added yet
     run_alert.details["expected_end_time"] = 1123922544.0
-    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=timezone.utc) == run_alert.expected_end_time
+    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=UTC) == run_alert.expected_end_time
 
 
 @pytest.mark.integration
@@ -134,8 +134,8 @@ def test_run_alert_expected_times_naive(pipeline_run):
     run_alert.expected_start_time = datetime(2005, 8, 13, 8, 42, 24)
     run_alert.expected_end_time = datetime(2005, 8, 13, 8, 55, 24)
 
-    assert run_alert.expected_start_time == datetime(2005, 8, 13, 8, 42, 24, tzinfo=timezone.utc)
-    assert run_alert.expected_end_time == datetime(2005, 8, 13, 8, 55, 24, tzinfo=timezone.utc)
+    assert run_alert.expected_start_time == datetime(2005, 8, 13, 8, 42, 24, tzinfo=UTC)
+    assert run_alert.expected_end_time == datetime(2005, 8, 13, 8, 55, 24, tzinfo=UTC)
 
 
 @pytest.mark.integration
@@ -153,7 +153,7 @@ def test_instance_alert_expected_start_time_get(instance):
         instance=instance, name="A", description="A", message="A", level=AlertLevel.WARNING, type="invalid"
     )
     instance_alert.details["expected_start_time"] = 1123922544.0
-    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=timezone.utc) == instance_alert.expected_start_time
+    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=UTC) == instance_alert.expected_start_time
 
 
 @pytest.mark.integration
@@ -171,7 +171,7 @@ def test_instance_alert_expected_end_time_get(instance):
         instance=instance, name="A", description="A", message="A", level=AlertLevel.WARNING, type="invalid"
     )
     instance_alert.details["expected_end_time"] = 1123922544.0
-    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=timezone.utc) == instance_alert.expected_end_time
+    assert datetime(2005, 8, 13, 8, 42, 24, tzinfo=UTC) == instance_alert.expected_end_time
 
 
 @pytest.mark.integration
@@ -183,8 +183,8 @@ def test_instance_alert_expected_times_naive(instance):
     instance_alert.expected_start_time = datetime(2005, 8, 13, 8, 42, 24)
     instance_alert.expected_end_time = datetime(2005, 8, 13, 8, 55, 24)
 
-    assert instance_alert.expected_start_time == datetime(2005, 8, 13, 8, 42, 24, tzinfo=timezone.utc)
-    assert instance_alert.expected_end_time == datetime(2005, 8, 13, 8, 55, 24, tzinfo=timezone.utc)
+    assert instance_alert.expected_start_time == datetime(2005, 8, 13, 8, 42, 24, tzinfo=UTC)
+    assert instance_alert.expected_end_time == datetime(2005, 8, 13, 8, 55, 24, tzinfo=UTC)
 
 
 @pytest.mark.integration

--- a/common/tests/integration/entities/test_runs.py
+++ b/common/tests/integration/entities/test_runs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 
 import pytest
 from peewee import IntegrityError
@@ -29,7 +29,7 @@ def test_add_pipeline_run_listening(pipeline):
     run.save()
 
     # After adding non-RUNNING status, listening should be False
-    run.end_time = datetime.utcnow().replace(tzinfo=timezone.utc) + timedelta(days=3)
+    run.end_time = datetime.utcnow().replace(tzinfo=UTC) + timedelta(days=3)
     run.status = "COMPLETED"
     run.save()
 

--- a/common/tests/integration/entity_services/conftest.py
+++ b/common/tests/integration/entity_services/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 
@@ -26,7 +26,7 @@ def pipeline_4(test_db, project):
 
 @pytest.fixture
 def current_time() -> datetime:
-    yield datetime.now(timezone.utc)
+    yield datetime.now(UTC)
 
 
 @pytest.fixture()
@@ -61,7 +61,7 @@ def test_outcomes_instance(test_db, run, pipeline, instance_instance_set):
 
 @pytest.fixture
 def test_outcomes_event(project, pipeline, run, event_data):
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(UTC).isoformat()
     data = {
         "event_type": TestOutcomesEvent.__name__,
         "test_outcomes": [

--- a/common/tests/integration/entity_services/test_project_service.py
+++ b/common/tests/integration/entity_services/test_project_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from typing import Optional
 from uuid import uuid4
 
@@ -47,7 +47,7 @@ def local_test_db(test_db):
 
 
 def _add_runs(
-    pipeline, instance, number_of_runs: int, current_time: datetime, *, expected_start_time: Optional[datetime] = None
+    pipeline, instance, number_of_runs: int, current_time: datetime, *, expected_start_time: datetime | None = None
 ):
     instance_set = InstanceSet.get_or_create([instance.id])
     for key in range(1, number_of_runs + 1):
@@ -158,19 +158,19 @@ def test_get_runs_with_rules_coalesce_sort(pipeline, instance, patched_instance_
     err_level = AlertLevel["ERROR"].value
     late_type = RunAlertType["LATE_END"].value
 
-    r1_expected_start = datetime(2023, 5, 25, 7, 44, 1, tzinfo=timezone.utc)
+    r1_expected_start = datetime(2023, 5, 25, 7, 44, 1, tzinfo=UTC)
     r1 = Run.create(
         key="coalesce-run-1",
         pipeline=pipeline,
         instance_set=instance_set,
         expected_start_time=r1_expected_start,
-        start_time=datetime(2023, 5, 25, 7, 44, 6, tzinfo=timezone.utc),
-        end_time=datetime(2023, 5, 25, 7, 45, 6, tzinfo=timezone.utc),
+        start_time=datetime(2023, 5, 25, 7, 44, 6, tzinfo=UTC),
+        end_time=datetime(2023, 5, 25, 7, 45, 6, tzinfo=UTC),
         status=RunStatus.COMPLETED.name,
     )
     RunAlert.create(name="CA1", description="CD1", level=err_level, type=late_type, run=r1)
 
-    r2_expected_start = datetime(2023, 5, 25, 7, 45, 10, tzinfo=timezone.utc)
+    r2_expected_start = datetime(2023, 5, 25, 7, 45, 10, tzinfo=UTC)
     r2 = Run.create(
         pipeline=pipeline,
         instance_set=instance_set,
@@ -181,14 +181,14 @@ def test_get_runs_with_rules_coalesce_sort(pipeline, instance, patched_instance_
     )
     RunAlert.create(name="CA2", description="CD2", level=err_level, type=late_type, run=r2)
 
-    r3_expected_start = datetime(2023, 5, 25, 7, 46, 1, tzinfo=timezone.utc)
+    r3_expected_start = datetime(2023, 5, 25, 7, 46, 1, tzinfo=UTC)
     r3 = Run.create(
         key="coalesce-run-3",
         pipeline=pipeline,
         instance_set=instance_set,
         expected_start_time=r3_expected_start,
-        start_time=datetime(2023, 5, 25, 7, 46, 22, tzinfo=timezone.utc),
-        end_time=datetime(2023, 5, 25, 7, 49, 12, tzinfo=timezone.utc),
+        start_time=datetime(2023, 5, 25, 7, 46, 22, tzinfo=UTC),
+        end_time=datetime(2023, 5, 25, 7, 49, 12, tzinfo=UTC),
         status=RunStatus.COMPLETED_WITH_WARNINGS.name,
     )
     RunAlert.create(name="CA3", description="CD3", level=err_level, type=late_type, run=r3)

--- a/common/tests/integration/entity_services/test_upcoming_instance_services.py
+++ b/common/tests/integration/entity_services/test_upcoming_instance_services.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from uuid import uuid4
 
 import pytest
@@ -282,7 +282,7 @@ def test_get_upcoming_instances_with_rules_discard_matching_existing_instance(
     instance_rule_end,
     current_time,
 ):
-    base_time = datetime(2023, 8, 21, 10, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2023, 8, 21, 10, 0, 0, tzinfo=UTC)
     instance.start_time = base_time
     instance.save()
     instance_rule_end.expression = "30 * * * *"
@@ -307,7 +307,7 @@ def test_get_upcoming_instances_with_rules_do_not_discard_upcoming_instance(
     instance_rule_end,
     current_time,
 ):
-    base_time = datetime(2023, 8, 21, 10, 0, 0, tzinfo=timezone.utc)
+    base_time = datetime(2023, 8, 21, 10, 0, 0, tzinfo=UTC)
     instance.start_time = base_time
     instance.save()
     instance_rule_start.expression = "5 * * * *"

--- a/common/tests/integration/test_apscheduler_extensions.py
+++ b/common/tests/integration/test_apscheduler_extensions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from itertools import count
 
 import pytest
@@ -12,7 +12,7 @@ from common.apscheduler_extensions import DelayedTrigger
 
 def calculate_fire_time_sequence(trigger, n=10):
     prev_fire_time = None
-    now = datetime.now(tz=getattr(trigger, "timezone", timezone.utc))
+    now = datetime.now(tz=getattr(trigger, "timezone", UTC))
     for _ in range(n):
         next_fire_time = trigger.get_next_fire_time(prev_fire_time, now)
         yield next_fire_time
@@ -24,21 +24,21 @@ def calculate_fire_time_sequence(trigger, n=10):
 @pytest.mark.parametrize(
     "trigger",
     (
-        CronTrigger.from_crontab("*/2 * * * *", timezone=timezone.utc),
-        CronTrigger.from_crontab("*/4 * * * *", timezone=timezone.utc),
+        CronTrigger.from_crontab("*/2 * * * *", timezone=UTC),
+        CronTrigger.from_crontab("*/4 * * * *", timezone=UTC),
         CronTrigger(
             year="*",
             month="*",
             day="*",
             hour="*",
             minute="*/4",
-            timezone=timezone.utc,
-            start_date=datetime.now(tz=timezone.utc) + timedelta(days=5),
+            timezone=UTC,
+            start_date=datetime.now(tz=UTC) + timedelta(days=5),
         ),
         CronTrigger.from_crontab("*/4 * * * *", timezone=astimezone("Asia/Tokyo")),
-        IntervalTrigger(minutes=1, timezone=timezone.utc),
-        IntervalTrigger(minutes=6, timezone=timezone.utc),
-        DateTrigger(timezone=timezone.utc),
+        IntervalTrigger(minutes=1, timezone=UTC),
+        IntervalTrigger(minutes=6, timezone=UTC),
+        DateTrigger(timezone=UTC),
     ),
     ids=(
         "cron_smaller_interval",
@@ -73,7 +73,7 @@ def test_delayed_trigger_3_min_delay(trigger):
     ),
 )
 def test_delayed_trigger(delay):
-    cron_trigger = CronTrigger.from_crontab("*/2 * * * *", timezone=timezone.utc)
+    cron_trigger = CronTrigger.from_crontab("*/2 * * * *", timezone=UTC)
     delayed_trigger = DelayedTrigger(cron_trigger, delay)
 
     for idx, original, delayed in zip(

--- a/common/tests/unit/actions/test_webhook_action.py
+++ b/common/tests/unit/actions/test_webhook_action.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import Mock, patch
 
 import pytest
@@ -19,7 +19,7 @@ def session():
 
 @pytest.fixture
 def test_outcome_item_data():
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(UTC).isoformat()
     return {
         "name": "My_test_name",
         "status": TestStatuses.PASSED.name,

--- a/common/tests/unit/entities/test_journey_dag.py
+++ b/common/tests/unit/entities/test_journey_dag.py
@@ -10,7 +10,7 @@ from common.entities import Journey
 
 @dataclass
 class FakeEdge:
-    left: Optional[str]
+    left: str | None
     right: str
 
     def __hash__(self):

--- a/common/tests/unit/entity_services/helpers/test_filter_rules.py
+++ b/common/tests/unit/entity_services/helpers/test_filter_rules.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from uuid import uuid4
 
 import pytest
@@ -58,8 +58,8 @@ def test_from_params_start():
 
     # We want to see that arrow is giving us the kind of timestamp we think; i.e., a UTC aware
     # timestamp.
-    assert filters.start_range_begin == datetime(year=2022, month=8, day=16, tzinfo=timezone.utc)
-    assert filters.start_range_end == datetime(year=2022, month=8, day=17, tzinfo=timezone.utc)
+    assert filters.start_range_begin == datetime(year=2022, month=8, day=16, tzinfo=UTC)
+    assert filters.start_range_end == datetime(year=2022, month=8, day=17, tzinfo=UTC)
     assert filters.end_range_begin is None
     assert filters.end_range_end is None
     assert bool(filters)
@@ -102,8 +102,8 @@ def test_run_filters_from_parameters_end():
         [("page", "5"), ("count", "25"), ("end_range_begin", "2022-08-16"), ("end_range_end", "2022-08-17")]
     )
     filters = RunFilters.from_params(end)
-    assert filters.end_range_begin == datetime(year=2022, month=8, day=16, tzinfo=timezone.utc)
-    assert filters.end_range_end == datetime(year=2022, month=8, day=17, tzinfo=timezone.utc)
+    assert filters.end_range_begin == datetime(year=2022, month=8, day=16, tzinfo=UTC)
+    assert filters.end_range_end == datetime(year=2022, month=8, day=17, tzinfo=UTC)
     assert filters.start_range_begin is None
     assert filters.start_range_end is None
     assert filters.pipeline_keys == []

--- a/common/tests/unit/events/v1/test_base_events.py
+++ b/common/tests/unit/events/v1/test_base_events.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta, timezone
+from datetime import timedelta, timezone, UTC
 
 import pytest
 from marshmallow import ValidationError
@@ -127,8 +127,8 @@ def test_event_with_batch_pipeline_component_missing_run_key_error(valid_event_d
 @pytest.mark.parametrize(
     ["timestamp", "tz"],
     [
-        ("2018-07-25T00:00:00Z", timezone.utc),
-        ("2018-07-25T00:00:00", timezone.utc),
+        ("2018-07-25T00:00:00Z", UTC),
+        ("2018-07-25T00:00:00", UTC),
         ("2014-12-22T03:12:58.019077+06:00", timezone(timedelta(hours=6))),
     ],
     ids=["ZuluTime", "Naive", "TZ offset"],

--- a/common/tests/unit/events/v1/test_testoutcomes.py
+++ b/common/tests/unit/events/v1/test_testoutcomes.py
@@ -38,9 +38,9 @@ def test_testoutcomes_schema_with_testgen_integration(test_outcomes_testgen_even
     assert item_integration_event.test_suite == item_integration_data["test_suite"]
     assert item_integration_event.version == item_integration_data["version"]
     assert len(item_integration_event.test_parameters) == len(item_integration_data["test_parameters"])
-    assert (
-        type(item_integration_event.test_parameters[0].value) == Decimal
-    ), "expected dataclass's value to be Decimal type"
+    assert type(item_integration_event.test_parameters[0].value) == Decimal, (
+        "expected dataclass's value to be Decimal type"
+    )
     assert str(item_integration_event.test_parameters[0].value) == item_integration_data["test_parameters"][0]["value"]
     assert item_integration_event.test_parameters[0].name == item_integration_data["test_parameters"][0]["name"]
     assert item_integration_event.columns == item_integration_data["columns"]

--- a/common/tests/unit/events/v2/test_test_outcomes.py
+++ b/common/tests/unit/events/v2/test_test_outcomes.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from decimal import Decimal
 
 import pytest
@@ -172,8 +172,8 @@ def test_test_outcomes(
     for actual, expected in zip(res.test_outcomes, test_outcome_items):
         assert actual.name == expected.name
         assert actual.description == expected.description
-        assert actual.start_time == datetime.fromisoformat(expected.start_time).replace(tzinfo=timezone.utc)
-        assert actual.end_time == datetime.fromisoformat(expected.end_time).replace(tzinfo=timezone.utc)
+        assert actual.start_time == datetime.fromisoformat(expected.start_time).replace(tzinfo=UTC)
+        assert actual.end_time == datetime.fromisoformat(expected.end_time).replace(tzinfo=UTC)
         assert actual.metric_value == expected.metric_value
         assert actual.metric_name == expected.metric_name
         assert actual.metric_description == expected.metric_description
@@ -201,9 +201,9 @@ def test_testoutcomes_schema_with_testgen_integration(test_outcomes_testgen_data
     assert item_integration_event.test_suite == item_integration_data["test_suite"]
     assert item_integration_event.version == item_integration_data["version"]
     assert len(item_integration_event.test_parameters) == len(item_integration_data["test_parameters"])
-    assert (
-        type(item_integration_event.test_parameters[0].value) == Decimal
-    ), "expected dataclass's value to be Decimal type"
+    assert type(item_integration_event.test_parameters[0].value) == Decimal, (
+        "expected dataclass's value to be Decimal type"
+    )
     assert str(item_integration_event.test_parameters[0].value) == item_integration_data["test_parameters"][0]["value"]
     assert item_integration_event.test_parameters[0].name == item_integration_data["test_parameters"][0]["name"]
     assert item_integration_event.columns == item_integration_data["columns"]

--- a/common/tests/unit/flask_ext/test_jwt_plugin.py
+++ b/common/tests/unit/flask_ext/test_jwt_plugin.py
@@ -1,7 +1,7 @@
 import json
 from base64 import b64decode, b64encode
 from binascii import Error as B64DecodeError
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -50,7 +50,7 @@ def expired_token():
 @pytest.fixture
 def current_token():
     data = TOKEN_DATA.copy()
-    dt = datetime.now(timezone.utc) + timedelta(days=2)
+    dt = datetime.now(UTC) + timedelta(days=2)
     data["exp"] = int(dt.replace(microsecond=0).timestamp())
     return encode(data, key=JWT_KEY)
 
@@ -64,8 +64,8 @@ def user():
 @pytest.mark.parametrize(
     ("ts_value", "dt_value"),
     [
-        (40, datetime(1970, 1, 1, 0, 0, 40, tzinfo=timezone.utc)),
-        (435474000, datetime(1983, 10, 20, 5, 0, tzinfo=timezone.utc)),
+        (40, datetime(1970, 1, 1, 0, 0, 40, tzinfo=UTC)),
+        (435474000, datetime(1983, 10, 20, 5, 0, tzinfo=UTC)),
     ],
 )
 def test_get_expiration_int(ts_value, dt_value):

--- a/common/tests/unit/peewee_extensions/test_peewee_extensions.py
+++ b/common/tests/unit/peewee_extensions/test_peewee_extensions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from enum import Enum, IntEnum
 from zoneinfo import ZoneInfo
 
@@ -82,7 +82,7 @@ def test_domain_field_lowercase():
 @pytest.mark.unit
 def test_timestamp_to_utc():
     """UTCTimestampField.python_value returns timezone aware values."""
-    expected_dt = datetime.now(timezone.utc)
+    expected_dt = datetime.now(UTC)
     f_inst = UTCTimestampField()
     db_value = f_inst.db_value(expected_dt)
     result = f_inst.python_value(db_value)

--- a/common/tests/unit/predicate_engine/assertions.py
+++ b/common/tests/unit/predicate_engine/assertions.py
@@ -42,7 +42,7 @@ def assertRuleEqual(a, b, default_op="exact"):
         raise AssertionError(f"Rules differ: \n\t{str_a}\n\t!=\n\t{str_b}")
 
 
-def assertRuleMatches(a: R, b: Any, msg: Optional[str] = None):
+def assertRuleMatches(a: R, b: Any, msg: str | None = None):
     """Assert that an R object matches a given value."""
     try:
         result = a.matches(b)
@@ -65,7 +65,7 @@ def assertRuleMatches(a: R, b: Any, msg: Optional[str] = None):
             )
 
 
-def assertRuleNotMatches(a: R, b: Any, msg: Optional[str] = None):
+def assertRuleNotMatches(a: R, b: Any, msg: str | None = None):
     try:
         result = a.matches(b)
     except Exception:

--- a/common/tests/unit/predicate_engine/conftest.py
+++ b/common/tests/unit/predicate_engine/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 
@@ -33,7 +33,7 @@ class EntityClass:
 
     @property
     def timestamp_dt(self) -> datetime:
-        return datetime(1983, 10, 20, 10, 10, 10, tzinfo=timezone.utc)
+        return datetime(1983, 10, 20, 10, 10, 10, tzinfo=UTC)
 
 
 @pytest.fixture(scope="session")

--- a/common/tests/unit/predicate_engine/test_predicate_engine.py
+++ b/common/tests/unit/predicate_engine/test_predicate_engine.py
@@ -2,7 +2,7 @@ import random
 import sys
 from collections.abc import MutableMapping
 from copy import copy
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unicodedata import category
 
 import pytest
@@ -193,7 +193,7 @@ def test_matching_invalid_data_types(rule, simple_entity):
 @pytest.mark.parametrize(
     "rule",
     (
-        R(timestamp__gte=datetime.now(timezone.utc)),
+        R(timestamp__gte=datetime.now(UTC)),
         R(timestamp_dt__gte=datetime.now()),
     ),
 )

--- a/common/tests/unit/test_apscheduler_extensions.py
+++ b/common/tests/unit/test_apscheduler_extensions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
@@ -15,7 +15,7 @@ from common.apscheduler_extensions import (
 
 @pytest.mark.unit
 def test_delayed_trigger_negative():
-    cron_trigger = CronTrigger.from_crontab("*/2 * * * *", timezone=timezone.utc)
+    cron_trigger = CronTrigger.from_crontab("*/2 * * * *", timezone=UTC)
     delay = timedelta(hours=-1)
     with pytest.raises(ValueError, match="positive"):
         DelayedTrigger(cron_trigger, delay)
@@ -102,8 +102,8 @@ def test_fix_weekdays(weekday_expression, expected):
 
 @pytest.mark.unit
 def test_get_crontab_trigger_times_finite_range():
-    start = datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    end = datetime(2000, 1, 10, 0, 0, 0, tzinfo=timezone.utc)
+    start = datetime(2000, 1, 1, 0, 0, 0, tzinfo=UTC)
+    end = datetime(2000, 1, 10, 0, 0, 0, tzinfo=UTC)
     for i, time in enumerate(get_crontab_trigger_times("0 10 * * *", ZoneInfo("UTC"), start, end)):
         assert time == start + timedelta(days=i, hours=10)
     assert i == 8
@@ -111,7 +111,7 @@ def test_get_crontab_trigger_times_finite_range():
 
 @pytest.mark.unit
 def test_get_crontab_trigger_times_infinite_range():
-    start = datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    start = datetime(2000, 1, 1, 0, 0, 0, tzinfo=UTC)
     gen = get_crontab_trigger_times("0 10 * * *", ZoneInfo("UTC"), start)
     for i in range(5000):
         assert next(gen) == start + timedelta(days=i, hours=10)
@@ -122,7 +122,7 @@ def test_get_crontab_trigger_times_infinite_range():
     "start,end",
     (
         (datetime(2000, 1, 1, 0, 0, 0), None),
-        (datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc), datetime(2000, 1, 2, 0, 0, 0)),
+        (datetime(2000, 1, 1, 0, 0, 0, tzinfo=UTC), datetime(2000, 1, 2, 0, 0, 0)),
     ),
 )
 def test_get_crontab_trigger_times_invalid_range(start, end):

--- a/common/tests/unit/test_datetime_utils.py
+++ b/common/tests/unit/test_datetime_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from zoneinfo import ZoneInfo, available_timezones
 
 import pytest
@@ -26,10 +26,10 @@ def test_datetime_iso8601():
 @pytest.mark.parametrize(
     "ts, dt",
     (
-        (1685701704.039912, datetime(2023, 6, 2, 10, 28, 24, 39912, tzinfo=timezone.utc)),
-        (1123905724.000002, datetime(2005, 8, 13, 4, 2, 4, 2, tzinfo=timezone.utc)),
-        (435489642.424242, datetime(1983, 10, 20, 9, 20, 42, 424242, tzinfo=timezone.utc)),
-        (1162815179.06429, datetime(2006, 11, 6, 12, 12, 59, 64290, tzinfo=timezone.utc)),
+        (1685701704.039912, datetime(2023, 6, 2, 10, 28, 24, 39912, tzinfo=UTC)),
+        (1123905724.000002, datetime(2005, 8, 13, 4, 2, 4, 2, tzinfo=UTC)),
+        (435489642.424242, datetime(1983, 10, 20, 9, 20, 42, 424242, tzinfo=UTC)),
+        (1162815179.06429, datetime(2006, 11, 6, 12, 12, 59, 64290, tzinfo=UTC)),
     ),
 )
 def test_timestamp_and_datetime(ts, dt):
@@ -47,7 +47,7 @@ def test_tzinfo_added():
     naive_dt = datetime(2006, 11, 6, 12, 12)
     timestamp = datetime_to_timestamp(naive_dt)
 
-    expected_dt = datetime(2006, 11, 6, 12, 12, tzinfo=timezone.utc)
+    expected_dt = datetime(2006, 11, 6, 12, 12, tzinfo=UTC)
     actual_dt = timestamp_to_datetime(timestamp)
 
     assert actual_dt != naive_dt
@@ -65,7 +65,7 @@ def test_tzinfo_coerced_to_utc():
     tz_dt = datetime(2001, 1, 1, 0, 0, 0, tzinfo=tzinfo)
     timestamp = datetime_to_timestamp(tz_dt)
 
-    expected_dt = tz_dt.astimezone(timezone.utc)
+    expected_dt = tz_dt.astimezone(UTC)
     actual_dt = timestamp_to_datetime(timestamp)
 
     assert expected_dt == actual_dt

--- a/common/tests/unit/test_messagepack.py
+++ b/common/tests/unit/test_messagepack.py
@@ -1,7 +1,7 @@
 from array import array
 from collections import OrderedDict
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from decimal import Decimal
 from io import BytesIO
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
@@ -159,7 +159,7 @@ def test_dump_load_datetime():
 @pytest.mark.unit
 def test_dump_load_datetime_tzinfo():
     """Messagepack can dump/load datetime.datetime values and preserve tzinfo."""
-    data = datetime.now(timezone.utc)
+    data = datetime.now(UTC)
     out_value = loads(dumps(data))
     assert data == out_value
 

--- a/deploy/search_view_plugin.py
+++ b/deploy/search_view_plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from apispec import BasePlugin
 from apispec.yaml_utils import load_yaml_from_docstring
@@ -16,8 +16,8 @@ class SearchViewPlugin(BasePlugin):
 
     def operation_helper(
         self,
-        path: Optional[str] = None,
-        operations: Optional[dict] = None,
+        path: str | None = None,
+        operations: dict | None = None,
         **kwargs: Any,
     ) -> None:
         view_class = getattr(kwargs.get("view", None), "view_class", None)

--- a/deploy/subcomponent_plugin.py
+++ b/deploy/subcomponent_plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from apispec import BasePlugin
 
@@ -15,8 +15,8 @@ class SubcomponentPlugin(BasePlugin):
 
     def operation_helper(
         self,
-        path: Optional[str] = None,
-        operations: Optional[dict] = None,
+        path: str | None = None,
+        operations: dict | None = None,
         **kwargs: Any,
     ) -> None:
         description_dict: dict[str, str] = {
@@ -58,7 +58,7 @@ class SubcomponentPlugin(BasePlugin):
         }
         return request_body
 
-    def parameter_helper(self, parameter: Optional[dict] = None, **kwargs: Any) -> dict:
+    def parameter_helper(self, parameter: dict | None = None, **kwargs: Any) -> dict:
         method = kwargs["method"]
         parameter = {"in": "path", "schema": {"type": "string"}, "required": "true", "name": "component_id"}
         if method == "post":
@@ -66,7 +66,7 @@ class SubcomponentPlugin(BasePlugin):
             parameter["description"] = f"The ID of the project that the {self.subcomponent_name} will be created under."
         return parameter
 
-    def response_helper(self, response: Optional[dict] = None, **kwargs: Any) -> dict:
+    def response_helper(self, response: dict | None = None, **kwargs: Any) -> dict:
         method = kwargs["method"]
         response_desc_dict: dict[str, dict[int, str]] = {
             "get": {

--- a/event_api/config/defaults.py
+++ b/event_api/config/defaults.py
@@ -5,13 +5,12 @@ Settings here may be overridden by settings in development, test, production, et
 """
 
 import os
-from typing import Optional
 
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
 from common.entities import Service
 
-PROPAGATE_EXCEPTIONS: Optional[bool] = None
-SERVER_NAME: Optional[str] = os.environ.get("EVENTS_API_HOSTNAME")  # Use flask defaults if none set
+PROPAGATE_EXCEPTIONS: bool | None = None
+SERVER_NAME: str | None = os.environ.get("EVENTS_API_HOSTNAME")  # Use flask defaults if none set
 USE_X_SENDFILE: bool = False  # If we serve files enable this in production settings when webserver support configured
 
 # Application settings

--- a/event_api/config/local.py
+++ b/event_api/config/local.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-PROPAGATE_EXCEPTIONS: Optional[bool] = True
+PROPAGATE_EXCEPTIONS: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"

--- a/event_api/config/minikube.py
+++ b/event_api/config/minikube.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-TESTING: Optional[bool] = True
+TESTING: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"

--- a/event_api/endpoints/v1/event_view.py
+++ b/event_api/endpoints/v1/event_view.py
@@ -1,7 +1,6 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from http import HTTPStatus
-from typing import Optional
 
 from flask import Response, current_app, g, make_response, request
 from marshmallow import ValidationError
@@ -34,14 +33,14 @@ class EventView(BaseView):
     event_type: type[Event]
     """The class (not instance) that is used to deserialize the incoming request body"""
 
-    def make_error(self, msg: str, e: Exception, error_code: Optional[int] = None) -> Response:
+    def make_error(self, msg: str, e: Exception, error_code: int | None = None) -> Response:
         """TODO: This should be turned into an ErrorHandler at the app level."""
         return make_response(
             {
                 "error": msg,
                 # TODO: Should this be exposed to the user?
                 "details": str(e),
-                "timestamp": datetime.now(tz=timezone.utc),
+                "timestamp": datetime.now(tz=UTC),
             },
             error_code if error_code else 500,
         )

--- a/event_api/tests/integration/v1_endpoints/conftest.py
+++ b/event_api/tests/integration/v1_endpoints/conftest.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -29,7 +29,7 @@ class DatabaseCtx:
 
 @pytest.fixture
 def predictable_datetime():
-    return datetime(2022, 5, 25, 19, 56, 52, 759419, tzinfo=timezone.utc)
+    return datetime(2022, 5, 25, 19, 56, 52, 759419, tzinfo=UTC)
 
 
 @pytest.fixture

--- a/event_api/tests/integration/v2_endpoints/conftest.py
+++ b/event_api/tests/integration/v2_endpoints/conftest.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,7 +18,7 @@ from event_api.routes import build_v2_routes
 
 @pytest.fixture
 def event_time():
-    return datetime(2022, 5, 25, 19, 56, 52, 759419, tzinfo=timezone.utc)
+    return datetime(2022, 5, 25, 19, 56, 52, 759419, tzinfo=UTC)
 
 
 @pytest.fixture

--- a/observability_api/config/defaults.py
+++ b/observability_api/config/defaults.py
@@ -6,13 +6,12 @@ Settings here may be overridden by settings in development, test, production, et
 
 import os
 from datetime import timedelta
-from typing import Optional
 
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
 from common.entities import Service
 
-PROPAGATE_EXCEPTIONS: Optional[bool] = None
-SERVER_NAME: Optional[str] = os.environ.get("OBSERVABILITY_API_HOSTNAME")  # Use flask defaults if none set
+PROPAGATE_EXCEPTIONS: bool | None = None
+SERVER_NAME: str | None = os.environ.get("OBSERVABILITY_API_HOSTNAME")  # Use flask defaults if none set
 USE_X_SENDFILE: bool = False  # If we serve files enable this in production settings when webserver support configured
 
 # Application settings

--- a/observability_api/config/local.py
+++ b/observability_api/config/local.py
@@ -1,7 +1,5 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-PROPAGATE_EXCEPTIONS: Optional[bool] = True
+PROPAGATE_EXCEPTIONS: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"
 
 # Application settings

--- a/observability_api/config/minikube.py
+++ b/observability_api/config/minikube.py
@@ -1,7 +1,5 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-TESTING: Optional[bool] = True
+TESTING: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"
 
 # Application settings

--- a/observability_api/config/test.py
+++ b/observability_api/config/test.py
@@ -1,7 +1,5 @@
-from typing import Optional
-
 # Flask specific settings: https://flask.palletsprojects.com/en/latest/config/#builtin-configuration-values
-PROPAGATE_EXCEPTIONS: Optional[bool] = True
+PROPAGATE_EXCEPTIONS: bool | None = True
 SECRET_KEY: str = "NOT_VERY_SECRET"
 TESTING: bool = True
 

--- a/observability_api/endpoints/component_view.py
+++ b/observability_api/endpoints/component_view.py
@@ -2,7 +2,7 @@ __all__ = ["ComponentByIdAbstractView", "ComponentListAbstractView"]
 
 import logging
 from http import HTTPStatus
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from flask import Blueprint, Response, make_response
@@ -22,7 +22,7 @@ class ComponentByIdAbstractView(BaseEntityView):
     route: str
     entity: type[BaseEntity]
     schema: type[ModelSchema]
-    patch_schema: Optional[type[ModelSchema]] = None
+    patch_schema: type[ModelSchema] | None = None
 
     def get(self, component_id: UUID) -> Response:
         component = self.get_entity_or_fail(self.entity, self.entity.id == component_id)

--- a/observability_api/endpoints/v1/journeys.py
+++ b/observability_api/endpoints/v1/journeys.py
@@ -3,7 +3,6 @@ __all__ = ["Journeys", "JourneyById", "JourneyDag", "JourneyDagEdgeById", "Journ
 import logging
 from graphlib import CycleError
 from http import HTTPStatus
-from typing import Optional
 from uuid import UUID
 
 from flask import Response, make_response, request
@@ -115,7 +114,7 @@ class Journeys(BaseEntityView):
 
         """
         _ = self.get_entity_or_fail(Project, Project.id == project_id)
-        component_id: Optional[str] = request.args.get("component_id", None)
+        component_id: str | None = request.args.get("component_id", None)
         page: Page = ProjectService.get_journeys_with_rules(
             str(project_id), ListRules.from_params(request.args), component_id=component_id
         )

--- a/observability_api/endpoints/v1/project_settings.py
+++ b/observability_api/endpoints/v1/project_settings.py
@@ -1,6 +1,6 @@
 __all__ = ["ProjectAlertsSettings"]
 
-from typing import Optional, cast, Any
+from typing import cast, Any
 from uuid import UUID
 
 from flask import Response, make_response
@@ -23,7 +23,7 @@ from observability_api.endpoints.entity_view import BaseEntityView
 class ProjectAlertsSettings(BaseEntityView):
     PERMISSION_REQUIREMENTS: tuple[Permission, ...] = (PERM_USER, PERM_PROJECT)
 
-    _project: Optional[Project]
+    _project: Project | None
 
     def get_request_schema(self) -> Schema:
         return Schema.from_dict(self.get_fields(), name=f"{self.__class__.__name__}Schema")()  # type: ignore[arg-type]

--- a/observability_api/schemas/event_schemas.py
+++ b/observability_api/schemas/event_schemas.py
@@ -52,8 +52,7 @@ class EventResponseSchema(Schema):
         required=True,
         metadata={
             "description": (
-                "The IDs of the components related to the event. The first item in the list is the primary "
-                "component. "
+                "The IDs of the components related to the event. The first item in the list is the primary component. "
             )
         },
     )

--- a/observability_api/tests/integration/v1_endpoints/conftest.py
+++ b/observability_api/tests/integration/v1_endpoints/conftest.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from decimal import Decimal
 
 import pytest
@@ -275,8 +275,8 @@ def test_outcome(client, instance_instance_set, instance_runs, pipeline):
         dimensions=["a", "b", "c"],
         status=TestStatuses.WARNING.name,
         run=instance_runs[0].id,
-        start_time=datetime.now(tz=timezone.utc) - timedelta(minutes=15),
-        end_time=datetime.now(tz=timezone.utc) - timedelta(minutes=5),
+        start_time=datetime.now(tz=UTC) - timedelta(minutes=15),
+        end_time=datetime.now(tz=UTC) - timedelta(minutes=5),
         component=pipeline,
         instance_set=instance_instance_set.instance_set,
         external_url="https://example.com",
@@ -299,8 +299,8 @@ def test_outcomes(client, instance_instance_set, pipeline):
             dimension=[f"a-{i}", f"b-{i}", f"c-{i}"],
             description=f"Description{i}",
             status=f"{TestStatuses.PASSED.name if i % 2 == 0 else TestStatuses.FAILED.name}",
-            start_time=datetime.now(tz=timezone.utc) + timedelta(minutes=5 * i),
-            end_time=datetime.now(tz=timezone.utc) + timedelta(minutes=15 * i),
+            start_time=datetime.now(tz=UTC) + timedelta(minutes=5 * i),
+            end_time=datetime.now(tz=UTC) + timedelta(minutes=15 * i),
             component=pipeline,
             instance_set=instance_instance_set.instance_set,
             external_url="https://example.com",

--- a/observability_api/tests/integration/v1_endpoints/test_alerts.py
+++ b/observability_api/tests/integration/v1_endpoints/test_alerts.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from http import HTTPStatus
 from uuid import uuid4
 
@@ -107,7 +107,7 @@ def test_list_project_alerts_search(client, g_user, project, instance_alert, ins
 
 @pytest.mark.integration
 def test_list_project_alerts_filters(client, g_user, project, instance_alert, instance_alert_components, run_alerts):
-    yesterday = datetime.now(tz=timezone.utc) - timedelta(days=1)
+    yesterday = datetime.now(tz=UTC) - timedelta(days=1)
     past_instance = Instance.create(journey=instance_alert.instance.journey, start_time=yesterday)
     past_instance_alert = InstanceAlert.create(
         id=uuid4(),

--- a/observability_api/tests/integration/v1_endpoints/test_service_account_keys.py
+++ b/observability_api/tests/integration/v1_endpoints/test_service_account_keys.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from http import HTTPStatus
 
 import pytest
@@ -24,7 +24,7 @@ def sa_key(client, project):
 
 @pytest.mark.integration
 def test_create_sa_key_success(client, g_user, project, sa_key_data):
-    today = datetime.now(timezone.utc)
+    today = datetime.now(UTC)
     response = client.post(
         f"/observability/v1/projects/{project.id}/service-account-key",
         headers={"Content-Type": "application/json"},
@@ -46,7 +46,7 @@ def test_create_sa_key_success(client, g_user, project, sa_key_data):
 @pytest.mark.integration
 def test_create_sa_key_with_name_and_description(client, g_user, project, sa_key_data):
     sa_key_data["description"] = "Whoa man, I'm just using this for auth"
-    today = datetime.now(timezone.utc)
+    today = datetime.now(UTC)
     response = client.post(
         f"/observability/v1/projects/{project.id}/service-account-key",
         headers={"Content-Type": "application/json"},

--- a/observability_api/tests/integration/v1_endpoints/test_upcoming_instances.py
+++ b/observability_api/tests/integration/v1_endpoints/test_upcoming_instances.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from http import HTTPStatus
 
 import pytest
@@ -14,7 +14,7 @@ def test_list_project_upcoming_instances_instance_schedule(client, journey, jour
     InstanceRule.create(journey=journey, action=InstanceRuleAction.END, expression="30,40 * * * *")
     InstanceRule.create(journey=journey_2, action=InstanceRuleAction.START, expression="10,50 * * * *")
 
-    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),
@@ -70,7 +70,7 @@ def test_list_project_upcoming_instances_batch_schedule(
     batch_end_schedule.schedule = "30 * * * *"
     batch_end_schedule.save()
 
-    start_time = datetime(1991, 2, 20, 10, 59, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 59, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),
@@ -94,7 +94,7 @@ def test_list_project_upcoming_instances_filters(client, journey, journey_2, ins
     InstanceRule.create(journey=journey, action=InstanceRuleAction.START, expression="10 * * * *")
     InstanceRule.create(journey=journey_2, action=InstanceRuleAction.START, expression="30 * * * *")
 
-    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),
@@ -148,7 +148,7 @@ def test_list_company_upcoming_instances_instance_schedule(client, organization,
     InstanceRule.create(journey=journey, action=InstanceRuleAction.START, expression="10 * * * *")
     InstanceRule.create(journey=journey_2, action=InstanceRuleAction.START, expression="30 * * * *")
 
-    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),
@@ -173,7 +173,7 @@ def test_list_company_upcoming_instances_filters(client, project, organization, 
     InstanceRule.create(journey=journey, action=InstanceRuleAction.START, expression="10 * * * *")
     InstanceRule.create(journey=journey_2, action=InstanceRuleAction.START, expression="30 * * * *")
 
-    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),
@@ -210,7 +210,7 @@ def test_list_company_upcoming_instances_filters(client, project, organization, 
 
 @pytest.mark.integration
 def test_list_project_upcoming_instances_sa_key_auth_ok(client, journey, journey_2, instance, g_project):
-    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),
@@ -223,7 +223,7 @@ def test_list_project_upcoming_instances_sa_key_auth_ok(client, journey, journey
 
 @pytest.mark.integration
 def test_list_company_upcoming_instances_sa_key_auth_forbidden(client, journey, journey_2, instance, g_project):
-    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=timezone.utc)
+    start_time = datetime(1991, 2, 20, 10, 00, 00, tzinfo=UTC)
     query = MultiDict(
         [
             ("start_range", start_time.isoformat()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,14 +48,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff~=0.7.3",
+    "ruff~=0.12.0",
     "invoke~=2.1.2",
     "lxml~=5.3.0",
-    "mypy~=1.5.0",
+    "mypy~=1.16.1",
     "pre-commit~=2.20.0",
-    "pytest-cov~=4.0.0",
-    "pytest-xdist~=3.1.0",
-    "pytest~=7.2.0",
+    "pytest-cov~=6.2.1",
+    "pytest-xdist~=3.7.0",
+    "pytest~=8.4.1",
     "pyyaml~=6.0",
     "types-PyYAML~=6.0.8",
     "types-requests==2.28.11.15",
@@ -229,6 +229,10 @@ module = "PIL.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "IPython.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "invoke"
 ignore_missing_imports = true
 
@@ -241,11 +245,19 @@ module = "msgpack.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "observability_plugins.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "marshmallow_union.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "pybars"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "yoyo.*"
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/rules_engine/journey_rules.py
+++ b/rules_engine/journey_rules.py
@@ -5,7 +5,7 @@ __all__ = ["get_rules", "JourneyRule"]
 import logging
 import time
 from functools import lru_cache
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable
 from uuid import UUID
 
@@ -33,19 +33,19 @@ class JourneyRule:
     def __init__(
         self,
         r_obj: R,
-        rule_entity: Optional[RuleEntity],
+        rule_entity: RuleEntity | None,
         *triggers: Callable,
-        journey_id: Optional[UUID] = None,
-        component_id: Optional[UUID] = None,
+        journey_id: UUID | None = None,
+        component_id: UUID | None = None,
     ) -> None:
         self.r_obj: R = r_obj
         self.rule_entity = rule_entity
-        self.triggers: tuple[Callable[[EVENT_TYPE, Optional[RuleEntity], Optional[UUID]], ActionResult], ...] = triggers
-        self.journey_id: Optional[UUID] = journey_id
-        self.component_id: Optional[UUID] = component_id
+        self.triggers: tuple[Callable[[EVENT_TYPE, RuleEntity | None, UUID | None], ActionResult], ...] = triggers
+        self.journey_id: UUID | None = journey_id
+        self.component_id: UUID | None = component_id
 
     @staticmethod
-    def _get_component_id(event: EVENT_TYPE) -> Optional[UUID]:
+    def _get_component_id(event: EVENT_TYPE) -> UUID | None:
         """Extract the component id from the given event."""
         match event:
             case Event():
@@ -81,7 +81,7 @@ class JourneyRule:
         return f"{self.__module__}.{self.__class__.__name__}: {self.r_obj}"
 
 
-def _execute_action(event: EVENT_TYPE, rule_entity: RuleEntity, journey_id: Optional[UUID]) -> Any:
+def _execute_action(event: EVENT_TYPE, rule_entity: RuleEntity, journey_id: UUID | None) -> Any:
     action_entity = JourneyService.get_action_by_implementation(rule_entity.journey_id, rule_entity.action)
     action = action_factory(rule_entity.action, rule_entity.action_args, action_entity)
     action.execute(event, rule_entity, journey_id)

--- a/rules_engine/rule_data.py
+++ b/rules_engine/rule_data.py
@@ -1,6 +1,5 @@
 __all__ = ["RuleData"]
 
-from typing import Optional
 from uuid import UUID
 
 from peewee import SelectQuery, fn
@@ -21,7 +20,7 @@ class DatabaseData:
     def __init__(self, event: EVENT_TYPE) -> None:
         self.event = event
 
-    def _get_batch_pipeline_id(self) -> Optional[UUID]:
+    def _get_batch_pipeline_id(self) -> UUID | None:
         match self.event:
             case Event():
                 return self.event.pipeline_id

--- a/rules_engine/tests/integration/conftest.py
+++ b/rules_engine/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
@@ -31,8 +31,8 @@ def base_event_data():
         "pipeline_name": None,
         "project_id": str(uuid4()),
         "source": EventSources.API.name,
-        "event_timestamp": str(datetime.now(timezone.utc)),
-        "received_timestamp": str(datetime.now(timezone.utc)),
+        "event_timestamp": str(datetime.now(UTC)),
+        "received_timestamp": str(datetime.now(UTC)),
         "external_url": "https://example.com",
         "metadata": {},
         "run_id": None,

--- a/rules_engine/tests/unit/test_data_points.py
+++ b/rules_engine/tests/unit/test_data_points.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 
@@ -206,7 +206,7 @@ def test_run_data_points(run_status_event, run, rule):
     # DataPoints is using the correct source
     assert run.status != run_status_event.status
     assert dps.run.status == run.status
-    assert dps.run.start_time == run.start_time.replace(tzinfo=timezone.utc).isoformat()
+    assert dps.run.start_time == run.start_time.replace(tzinfo=UTC).isoformat()
     assert dps.run.start_time_formatted == datetime_formatted(run.start_time)
     assert dps.run.end_time == "N/A"
     assert dps.run.end_time_formatted == "N/A"
@@ -221,7 +221,7 @@ def test_run_data_points_with_end_time(run_status_event, run, rule):
     run.save()
     dps = DataPoints(run_status_event, rule)
     # These are tested in a separate function because the run is cached in Event
-    assert dps.run.end_time == run.end_time.replace(tzinfo=timezone.utc).isoformat()
+    assert dps.run.end_time == run.end_time.replace(tzinfo=UTC).isoformat()
     assert dps.run.end_time_formatted == datetime_formatted(run.end_time)
 
 
@@ -260,9 +260,9 @@ def test_run_task_data_points_with_times(run_status_event, run_task, rule):
     run_task.save()
     dps = DataPoints(run_status_event, rule)
     # These are tested in a separate function because the run task is cached in Event
-    assert dps.run_task.start_time == run_task.start_time.replace(tzinfo=timezone.utc).isoformat()
+    assert dps.run_task.start_time == run_task.start_time.replace(tzinfo=UTC).isoformat()
     assert dps.run_task.start_time_formatted == datetime_formatted(run_task.start_time)
-    assert dps.run_task.end_time == run_task.end_time.replace(tzinfo=timezone.utc).isoformat()
+    assert dps.run_task.end_time == run_task.end_time.replace(tzinfo=UTC).isoformat()
     assert dps.run_task.end_time_formatted == datetime_formatted(run_task.end_time)
 
 

--- a/run_manager/alerts.py
+++ b/run_manager/alerts.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 from collections.abc import Iterable
 from uuid import UUID
 
@@ -82,8 +81,8 @@ def create_run_alert(alert_type: RunAlertType, run: Run, pipeline: Pipeline) -> 
 def create_instance_alert(
     alert_type: InstanceAlertType,
     instance: Instance,
-    component: Optional[Component] = None,
-    alert_components: Optional[Iterable[UUID]] = None,
+    component: Component | None = None,
+    alert_components: Iterable[UUID] | None = None,
 ) -> InstanceAlertEvent:
     alert_level = INSTANCE_ALERT_LEVELS[alert_type]
     alert_description = INSTANCE_ALERT_DESCRIPTIONS[alert_type].format(

--- a/run_manager/context.py
+++ b/run_manager/context.py
@@ -1,6 +1,5 @@
 __all__ = ["RunManagerContext"]
 from dataclasses import dataclass, field
-from typing import Optional
 from uuid import UUID
 
 from common.entities import Component, Instance, InstanceSet, Pipeline, Run, RunTask, Task
@@ -13,21 +12,21 @@ class RunManagerContext:
     A context object to pass a state around when handling events in run manager
     """
 
-    component: Optional[Component] = None
+    component: Component | None = None
     # Keeping pipeline to keep "pre" event v1 code intact, i.e. avoid significant refactoring effort
-    pipeline: Optional[Pipeline] = None
-    run: Optional[Run] = None
-    task: Optional[Task] = None
-    run_task: Optional[RunTask] = None
+    pipeline: Pipeline | None = None
+    run: Run | None = None
+    task: Task | None = None
+    run_task: RunTask | None = None
     instances: list[InstanceRef] = field(default_factory=list)
-    instance_set: Optional[InstanceSet] = None
+    instance_set: InstanceSet | None = None
     ended_instances: list[UUID | Instance] = field(default_factory=list)
     """List of instances that ended in this context"""
     created_run: bool = False
     """Indicates if the run was created during this context"""
     started_run: bool = False
     """Indicates if the run was started during this context"""
-    prev_run_status: Optional[str] = None
+    prev_run_status: str | None = None
     """Previous run status before being processed by the run handler.
        This is to check for unexpected run status changed"""
 

--- a/run_manager/event_handlers/component_identifier.py
+++ b/run_manager/event_handlers/component_identifier.py
@@ -1,7 +1,7 @@
 __all__ = ["ComponentIdentifier"]
 
 import logging
-from typing import Optional, cast
+from typing import cast
 
 from peewee import DoesNotExist
 
@@ -26,7 +26,7 @@ COMPONENT_TYPES = {class_.component_type: class_ for class_ in ALL_COMPONENTS}
 """Map event component type to db model"""
 
 
-def _get_component(event: Event) -> Optional[Component]:
+def _get_component(event: Event) -> Component | None:
     # v1 event can only have one (component type)_id
     if component_id := event.component_id:
         try:
@@ -57,7 +57,7 @@ def _get_component(event: Event) -> Optional[Component]:
     return component
 
 
-def _create_component(event: Event) -> Optional[Component]:
+def _create_component(event: Event) -> Component | None:
     component: Component = event.component_model.create(
         key=event.component_key, name=event.component_name, tool=event.component_tool, project_id=event.project_id
     )

--- a/run_manager/event_handlers/instance_handler.py
+++ b/run_manager/event_handlers/instance_handler.py
@@ -2,7 +2,7 @@ __all__ = ["InstanceHandler"]
 import logging
 from collections import defaultdict
 from itertools import chain
-from typing import Any, Optional, cast
+from typing import Any, cast
 from collections.abc import Callable, Mapping
 from uuid import UUID
 
@@ -34,7 +34,7 @@ from run_manager.context import RunManagerContext
 LOG = logging.getLogger(__name__)
 
 
-def _find_existing_instance(journey: Journey, with_run: bool, payload_key: Optional[str]) -> Optional[Instance]:
+def _find_existing_instance(journey: Journey, with_run: bool, payload_key: str | None) -> Instance | None:
     if payload_key is None:
         f: Callable[[Any], bool | Any] = lambda k: k.payload_key is None
     else:
@@ -234,7 +234,7 @@ class InstanceHandler(EventHandlerBase):
         identified_instances: list[InstanceRef] = []
         with_run = event.run_id is not None
         for journey in event.component_journeys:
-            payload_keys: list[Optional[str]] = [None]
+            payload_keys: list[str | None] = [None]
             if any(rule.action is InstanceRuleAction.END_PAYLOAD for rule in journey.instance_rules):
                 payload_keys.extend(event.payload_keys)
             for payload_key in payload_keys:

--- a/run_manager/event_handlers/run_handler.py
+++ b/run_manager/event_handlers/run_handler.py
@@ -1,7 +1,7 @@
 __all__ = ["RunHandler"]
 
 import logging
-from typing import Optional, cast
+from typing import cast
 
 from peewee import DoesNotExist
 
@@ -102,7 +102,7 @@ class RunHandler(EventHandlerBase):
                     f"for batch-pipeline {self.context.pipeline.id}"
                 )
 
-    def _get_run(self, event: Event, pipeline: Pipeline) -> Optional[Run]:
+    def _get_run(self, event: Event, pipeline: Pipeline) -> Run | None:
         """
         Get an existing run instance
 

--- a/run_manager/event_handlers/run_unexpected_status_change_handler.py
+++ b/run_manager/event_handlers/run_unexpected_status_change_handler.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from common.entities import RunAlertType, RunStatus
 from common.events import EventHandlerBase
@@ -19,7 +18,7 @@ ALERT_TYPES = {
 """Map new run status to alert type"""
 
 
-def _get_alert_type(context: RunManagerContext) -> Optional[RunAlertType]:
+def _get_alert_type(context: RunManagerContext) -> RunAlertType | None:
     if context.run is None:
         raise ValueError("The `run` attribute for the context object must be populated with a valid Run instance")
 
@@ -52,7 +51,7 @@ class RunUnexpectedStatusChangeHandler(EventHandlerBase):
     def handle_run_status(self, event: RunStatusEvent) -> bool:
         if (pipeline := self.context.pipeline) is None or (run := self.context.run) is None:
             raise ValueError(
-                "The context object must be populated with a valid Pipeline and Run instance " "for RunStatusEvent"
+                "The context object must be populated with a valid Pipeline and Run instance for RunStatusEvent"
             )
 
         if (alert_type := _get_alert_type(self.context)) is not None:

--- a/run_manager/tests/integration/conftest.py
+++ b/run_manager/tests/integration/conftest.py
@@ -1,6 +1,6 @@
 import uuid
 from dataclasses import replace
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from unittest.mock import MagicMock
 
 import pytest
@@ -57,7 +57,7 @@ def compare_event_data(unidentified_event, identified_event, pipeline, run, task
 
 @pytest.fixture
 def timestamp_now():
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)
 
 
 @pytest.fixture
@@ -367,7 +367,7 @@ def pipeline_end_payload_rule(journey, pipeline):
 
 @pytest.fixture
 def timestamp_now():
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)
 
 
 @pytest.fixture

--- a/run_manager/tests/integration/event_handlers/test_out_of_sequence_instance_handler.py
+++ b/run_manager/tests/integration/event_handlers/test_out_of_sequence_instance_handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 
@@ -47,8 +47,8 @@ class JourneyContext:
                     project=project,
                     instance_set=self.instance_set.id,
                     status=RunStatus.COMPLETED.name,
-                    start_time=datetime.now(tz=timezone.utc),
-                    end_time=datetime.now(tz=timezone.utc),
+                    start_time=datetime.now(tz=UTC),
+                    end_time=datetime.now(tz=UTC),
                 )
             )
             JourneyDagEdge.create(

--- a/run_manager/tests/integration/test_run_handler.py
+++ b/run_manager/tests/integration/test_run_handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from uuid import UUID
 
 import pytest
@@ -26,12 +26,12 @@ def test_run_handler_new_pending_metadata(run_status_event_pending, pipeline):
 
     # Retrieve the run and make sure the expected_start_time has been updated
     run = Run.get_by_id(handler.context.run.id)
-    assert run.expected_start_time == datetime(2005, 3, 1, 1, 1, 1, tzinfo=timezone.utc)
+    assert run.expected_start_time == datetime(2005, 3, 1, 1, 1, 1, tzinfo=UTC)
 
 
 @pytest.mark.integration
 def test_run_handler_no_overwrite_expected_start_time(run_status_event_missing, pipeline):
-    expected_start_time = datetime(2005, 3, 2, 2, 2, 2, tzinfo=timezone.utc)
+    expected_start_time = datetime(2005, 3, 2, 2, 2, 2, tzinfo=UTC)
     run = Run.create(
         id=UUID("dbed19e1-d0bb-4860-bbdf-9d768cb90764"),
         pipeline=pipeline,

--- a/run_manager/tests/integration/test_run_manager_instance.py
+++ b/run_manager/tests/integration/test_run_manager_instance.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from uuid import uuid4
 
 import pytest
@@ -257,7 +257,7 @@ def test_run_manager_dont_modify_previously_closed_instance(
 ):
     p1 = Pipeline.create(key="pipe1", project=project)
     j1 = Journey.create(name="journey1", project=project)
-    instance_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+    instance_time = datetime.utcnow().replace(tzinfo=UTC)
     i1 = Instance.create(journey=j1, start_time=instance_time, end_time=instance_time)
     InstanceRule.create(journey=j1, action=InstanceRuleAction.START, batch_pipeline=p1)
     InstanceRule.create(journey=j1, action=InstanceRuleAction.END, batch_pipeline=p1)

--- a/run_manager/tests/integration/test_run_manager_unordered_events.py
+++ b/run_manager/tests/integration/test_run_manager_unordered_events.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from uuid import uuid4
 
 import pytest
@@ -15,7 +15,7 @@ def test_keep_run_end_state_and_update_start_state(pipeline, kafka_consumer, kaf
     Keep the run end state (end time, status) when an old message is processed.
     Update the start time when older message is received.
     """
-    new_time = datetime.now(tz=timezone.utc)
+    new_time = datetime.now(tz=UTC)
     old_time = new_time - timedelta(minutes=5)
 
     old_start_status_message = run_status_message
@@ -60,7 +60,7 @@ def test_reopen_run_on_newer_status(
     assert run.end_time is not None
 
     # Re-open existing run
-    run_status_message.payload.event_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+    run_status_message.payload.event_timestamp = datetime.utcnow().replace(tzinfo=UTC)
     run_status_message.payload.event_id = uuid4()
     kafka_consumer.__iter__.return_value = iter((run_status_message,))
     run_manager.process_events()
@@ -77,7 +77,7 @@ def test_keep_task_end_state_and_update_start_state(kafka_consumer, kafka_produc
     Keep the task end state (end time, status) when an old message is processed.
     Update the start time when older message is received.
     """
-    new_time = datetime.now(tz=timezone.utc)
+    new_time = datetime.now(tz=UTC)
     old_time = new_time - timedelta(minutes=5)
     old_status_message = task_status_message
     old_status_message.payload.event_timestamp = old_time
@@ -122,7 +122,7 @@ def test_reopen_task_on_newer_status(pipeline, kafka_consumer, kafka_producer, r
     assert run.end_time is not None
 
     # Re-open existing run
-    run_status_message.payload.event_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+    run_status_message.payload.event_timestamp = datetime.utcnow().replace(tzinfo=UTC)
     run_status_message.payload.event_id = uuid4()
     kafka_consumer.__iter__.return_value = iter((run_status_message,))
     run_manager.process_events()

--- a/run_manager/tests/integration/test_scheduler_events.py
+++ b/run_manager/tests/integration/test_scheduler_events.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from uuid import uuid4
 
 import pytest
@@ -159,7 +159,7 @@ def test_scheduler_run_should_start_with_pending(
 ):
     """Check that pending runs are marked missing when start schedule occurs"""
     instance = Instance.create(journey=journey)
-    expected_start_time = datetime(2005, 3, 2, 2, 2, 2, tzinfo=timezone.utc)
+    expected_start_time = datetime(2005, 3, 2, 2, 2, 2, tzinfo=UTC)
     run = Run.create(
         status=RunStatus.PENDING.name,
         start_time=None,

--- a/scheduler/agent_check.py
+++ b/scheduler/agent_check.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, UTC
 
 from apscheduler.triggers.interval import IntervalTrigger
 
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 
 
 def _get_agent_status(check_interval_seconds: int, latest_heartbeat: datetime) -> AgentStatus:
-    lateness = (datetime.now(tz=timezone.utc) - latest_heartbeat).total_seconds()
+    lateness = (datetime.now(tz=UTC) - latest_heartbeat).total_seconds()
     if lateness > check_interval_seconds * settings.AGENT_STATUS_CHECK_OFFLINE_FACTOR:
         return AgentStatus.OFFLINE
     elif lateness > check_interval_seconds * settings.AGENT_STATUS_CHECK_UNHEALTHY_FACTOR:
@@ -65,7 +65,7 @@ class AgentCheckScheduleSource(ScheduleSource[AgentCheckSchedule]):
         )
 
     def _check_agents_are_online(self, project: Project) -> None:
-        check_threshold = datetime.now(tz=timezone.utc) - timedelta(seconds=project.agent_check_interval)
+        check_threshold = datetime.now(tz=UTC) - timedelta(seconds=project.agent_check_interval)
         for agent in Agent.select().where(
             Agent.project == project.id,
             Agent.latest_heartbeat < check_threshold,

--- a/scheduler/component_expectations.py
+++ b/scheduler/component_expectations.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Optional
 from uuid import UUID
 
 from apscheduler.triggers.cron import CronTrigger
@@ -29,7 +28,7 @@ class ComponentScheduleSource(ScheduleSource[Schedule]):
         component_id: UUID,
         schedule_type: ScheduleType,
         is_margin: bool,
-        margin: Optional[int] = None,
+        margin: int | None = None,
     ) -> None:
         """Create and forward corresponding scheduler event(s) to the run manager"""
         if is_margin:

--- a/scheduler/schedule_source.py
+++ b/scheduler/schedule_source.py
@@ -3,7 +3,7 @@ __all__ = ["ScheduleSource", "RunTimeExecutor"]
 import logging
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Optional, Protocol, Generic, TypeVar
+from typing import Any, Protocol, TypeVar
 from collections.abc import Callable
 
 from apscheduler.executors.pool import ThreadPoolExecutor
@@ -41,7 +41,7 @@ class Schedule(Protocol):
 ST = TypeVar("ST", bound=Schedule)
 
 
-class ScheduleSource(Generic[ST]):
+class ScheduleSource[ST: Schedule]:
     """Concentrates all features and configurations around a specific source of schedules."""
 
     source_name: str
@@ -65,7 +65,7 @@ class ScheduleSource(Generic[ST]):
     def executor_name(self) -> str:
         return self.source_name
 
-    def add_job(self, func: Callable, job_id: str, trigger: BaseTrigger, kwargs: Optional[dict[str, Any]]) -> Job:
+    def add_job(self, func: Callable, job_id: str, trigger: BaseTrigger, kwargs: dict[str, Any] | None) -> Job:
         return self.scheduler.add_job(
             func,
             id=job_id,

--- a/scheduler/tests/integration/test_agent_scheduler.py
+++ b/scheduler/tests/integration/test_agent_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, UTC
 from unittest.mock import patch
 
 import pytest
@@ -19,7 +19,7 @@ def agents(project):
             tool="tool",
             version="vTest",
             status=AgentStatus.ONLINE,
-            latest_heartbeat=datetime.now(tz=timezone.utc) - timedelta(seconds=elapsed_time),
+            latest_heartbeat=datetime.now(tz=UTC) - timedelta(seconds=elapsed_time),
         )
         for elapsed_time in (
             25,  # Below the checking threshold

--- a/scheduler/tests/integration/test_schedule_source.py
+++ b/scheduler/tests/integration/test_schedule_source.py
@@ -1,5 +1,5 @@
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import Mock, patch
 
 import pytest
@@ -29,7 +29,7 @@ class TestTrigger(BaseTrigger):
         if previous_fire_time:
             return None
         else:
-            return datetime.now(tz=timezone.utc)
+            return datetime.now(tz=UTC)
 
 
 class TestScheduleSource(ScheduleSource):

--- a/scheduler/tests/unit/conftest.py
+++ b/scheduler/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -42,7 +42,7 @@ def agent_source(scheduler, event_producer_mock):
 @pytest.fixture
 def job_kwargs():
     return {
-        "run_time": datetime.now(tz=timezone.utc),
+        "run_time": datetime.now(tz=UTC),
         "schedule_type": ScheduleType.BATCH_END_TIME,
         "schedule_id": str(uuid4()),
         "component_id": str(uuid4()),
@@ -64,4 +64,4 @@ def schedule_data():
 
 @pytest.fixture
 def run_time():
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)

--- a/scheduler/tests/unit/test_agent_scheduler.py
+++ b/scheduler/tests/unit/test_agent_scheduler.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, UTC
 from unittest.mock import patch
 
 import pytest
@@ -43,5 +43,5 @@ def test_add_job(agent_source):
     ],
 )
 def test_get_agent_status(elapsed_time, expected_status):
-    latest_heartbeat = datetime.now(tz=timezone.utc) - timedelta(seconds=elapsed_time)
+    latest_heartbeat = datetime.now(tz=UTC) - timedelta(seconds=elapsed_time)
     assert _get_agent_status(CHECK_INTERVAL, latest_heartbeat) == expected_status

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-# This file is here to support editable installs (pip install -e .)
-# https://github.com/pypa/setuptools/issues/2816

--- a/testlib/fixtures/entities.py
+++ b/testlib/fixtures/entities.py
@@ -61,7 +61,7 @@ __all__ = [
 
 import base64
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from decimal import Decimal
 from unittest.mock import patch
 from uuid import UUID
@@ -445,11 +445,11 @@ def batch_end_schedule(pipeline):
     )
 
 
-ALERT_EXPECTED_START_DT: datetime = datetime(2005, 8, 13, 4, 2, 4, 2, tzinfo=timezone.utc)
+ALERT_EXPECTED_START_DT: datetime = datetime(2005, 8, 13, 4, 2, 4, 2, tzinfo=UTC)
 """The datetime of the expected_start_time for alert fixtures."""
 
 
-ALERT_EXPECTED_END_DT: datetime = datetime(2005, 8, 13, 8, 4, 8, 1, tzinfo=timezone.utc)
+ALERT_EXPECTED_END_DT: datetime = datetime(2005, 8, 13, 8, 4, 8, 1, tzinfo=UTC)
 """The datetime of the expected_end_time for alert fixtures."""
 
 
@@ -496,8 +496,8 @@ def test_outcome(component, run, task):
         component=component,
         description="Testy McTestface",
         dimensions=["a", "b", "c"],
-        start_time=datetime(2000, 3, 9, 12, 11, 10, tzinfo=timezone.utc),
-        end_time=datetime(2000, 3, 9, 13, 12, 11, tzinfo=timezone.utc),
+        start_time=datetime(2000, 3, 9, 12, 11, 10, tzinfo=UTC),
+        end_time=datetime(2000, 3, 9, 13, 12, 11, tzinfo=UTC),
         name="test-outcome-1",
         external_url="https://fake.testy/do-not-go-here",
         key="test-outcome-key-1",
@@ -563,10 +563,10 @@ def testgen_dataset_component(test_db, dataset):
     yield dataset_component
 
 
-AGENT_LATEST_EVENT = datetime(2023, 10, 17, 12, 33, 19, 154295, tzinfo=timezone.utc)
+AGENT_LATEST_EVENT = datetime(2023, 10, 17, 12, 33, 19, 154295, tzinfo=UTC)
 """Default timestamp for latest event received by an agent."""
 
-AGENT_LATEST_HEARTBEAT = datetime(2023, 10, 17, 12, 42, 42, 424242, tzinfo=timezone.utc)
+AGENT_LATEST_HEARTBEAT = datetime(2023, 10, 17, 12, 42, 42, 424242, tzinfo=UTC)
 """Default timestamp for the lasttime an agent checked-in."""
 
 
@@ -585,7 +585,7 @@ def agent_1(test_db, project):
 
 @pytest.fixture()
 def agent_2(test_db, project):
-    dt_1 = datetime.now(timezone.utc)
+    dt_1 = datetime.now(UTC)
     dt_2 = dt_1 + timedelta(seconds=42)
     return Agent.create(
         project=project,
@@ -603,8 +603,8 @@ def event_entity(test_db, pipeline, task, run, run_task, instance_instance_set):
     return EventEntity.create(
         version=EventVersion.V2,
         type=ApiEventType.BATCH_PIPELINE_STATUS,
-        created_timestamp=datetime(2024, 1, 20, 10, 0, 0, tzinfo=timezone.utc),
-        timestamp=datetime(2024, 1, 20, 9, 59, 0, tzinfo=timezone.utc),
+        created_timestamp=datetime(2024, 1, 20, 10, 0, 0, tzinfo=UTC),
+        timestamp=datetime(2024, 1, 20, 9, 59, 0, tzinfo=UTC),
         project=pipeline.project_id,
         component=pipeline,
         task=task,
@@ -620,8 +620,8 @@ def event_entity_2(test_db, dataset):
     return EventEntity.create(
         version=EventVersion.V2,
         type=ApiEventType.DATASET_OPERATION,
-        created_timestamp=datetime(2024, 1, 20, 9, 55, 0, tzinfo=timezone.utc),
-        timestamp=datetime(2024, 1, 20, 9, 55, 0, tzinfo=timezone.utc),
+        created_timestamp=datetime(2024, 1, 20, 9, 55, 0, tzinfo=UTC),
+        timestamp=datetime(2024, 1, 20, 9, 55, 0, tzinfo=UTC),
         project=dataset.project_id,
         component=dataset,
         v2_payload={},

--- a/testlib/fixtures/v1_events.py
+++ b/testlib/fixtures/v1_events.py
@@ -32,7 +32,7 @@ __all__ = [
 ]
 
 
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from decimal import Decimal
 from uuid import UUID
 
@@ -220,7 +220,7 @@ def FAILED_run_status_event_data(FAILED_run_status_event):
 
 @pytest.fixture
 def test_outcome_item_data(metadata_model) -> dict:
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(UTC).isoformat()
     yield {
         "name": "My_test_name",
         "status": TestStatuses.PASSED.name,

--- a/testlib/fixtures/v2_events.py
+++ b/testlib/fixtures/v2_events.py
@@ -19,7 +19,7 @@ __all__ = [
     "test_outcomes_testgen_event_v2",
 ]
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from decimal import Decimal
 from uuid import UUID
 
@@ -84,7 +84,7 @@ BATCH_PIPELINE_STATUS_EVENT_ID: UUID = UUID("10f1eb1a-c63b-47d3-9239-e44d7bb5d07
 TEST_OUTCOMES_EVENT_ID: UUID = UUID("83af84bc-318e-4dda-9d40-6c7c8bacd992")
 """ID for EventV2 LOG event."""
 
-EVENT_TIMESTAMP: datetime = datetime(2023, 5, 10, 1, 1, 1, tzinfo=timezone.utc)
+EVENT_TIMESTAMP: datetime = datetime(2023, 5, 10, 1, 1, 1, tzinfo=UTC)
 """Default timestamp for events."""
 
 CREATED_TIMESTAMP: datetime = EVENT_TIMESTAMP + timedelta(minutes=3, seconds=1)
@@ -191,7 +191,7 @@ def run_alert() -> RunAlert:
 
 @pytest.fixture
 def test_outcome_item(metadata_model) -> TestOutcomeItem:
-    timestamp = datetime.now(timezone.utc)
+    timestamp = datetime.now(UTC)
     return TestOutcomeItem(
         name="My_test_name",
         status=TestStatus.PASSED,

--- a/testlib/peewee.py
+++ b/testlib/peewee.py
@@ -1,9 +1,10 @@
 import contextlib
 from unittest.mock import Mock, patch
+from typing import Any
 
 
 @contextlib.contextmanager
-def patch_select(target: str, **kwargs):
+def patch_select(target: str, **kwargs: Any) -> Any:
     with patch(target=f"{target}.select") as select_mock:
         select_mock.return_value = select_mock
         for attr in ("join", "left_outer_join", "switch", "order_by", "where"):


### PR DESCRIPTION
- Removed empty config.cfg hack (it was an ancient workaround for a problem that no longer exists)
- Updated ruff formatter config to format as python3.13 (the version of python used by the project)
- Fixed some outdated README.md text
- Upgraded mypy version
- Fixed type hint complaints from mypy
- Updated pytest & pytest plugin versions (fixes several noisy deprecation warnings)